### PR TITLE
Notice: Undefined index

### DIFF
--- a/modules/ft-featured-page/plugin.php
+++ b/modules/ft-featured-page/plugin.php
@@ -126,12 +126,19 @@ class FT_Featured_Page extends WP_Widget {
 	 * @param	array	instance	The array of keys and values for the widget.
 	 */
 	public function form( $instance ) {
-	
-    	// TODO:	Define default values for your variables
+
+    	// Default values for variables
 		$instance = wp_parse_args(
-			(array) $instance
+			(array) $instance,
+            array(
+                'title' => '',
+                'icon' => '',
+                'content' => '',
+                'button_text' => '',
+                'button_link' => ''
+            )
 		);
-	
+
 		// Set $template_var to instance[$template_var]
 		foreach (array('title', 'icon', 'content', 'button_text', 'button_link' ) as $field_name) {
 			$$field_name = $instance[ $field_name ];


### PR DESCRIPTION
Adding the FortyTwo featured page widget to a widget sidebar was throwing a warning;

Notice: Undefined index: {var}

I added in default values for variables which seems to sort out this issue, @mrdavidlaing can you once over ?
