### PR TITLE
Remove excerpt position options from responsive slider

### DIFF
--- a/lib/widgets/ft-responsive-slider/admin.php
+++ b/lib/widgets/ft-responsive-slider/admin.php
@@ -33,8 +33,6 @@ function ft_responsive_slider_defaults() {
 		'slideshow_more_text' => __( '[Continue Reading]', 'fortytwo' ),
 		'slideshow_excerpt_show' => 1,
 		'slideshow_excerpt_width' => 50,
-		'location_vertical' => 'bottom',
-		'location_horizontal' => 'right',
 		'slideshow_hide_mobile' => 1
 	);
 
@@ -411,22 +409,6 @@ function ft_responsive_slider_options_box() {
 				<p>
 					<label for="<?php echo FT_RESPONSIVE_SLIDER_SETTINGS_FIELD; ?>[slideshow_excerpt_width]"><?php _e( 'Slider Excerpt Width in Columns (1-12)', 'fortytwo' ); ?>:
 					<input type="text" id="<?php echo FT_RESPONSIVE_SLIDER_SETTINGS_FIELD; ?>[slideshow_excerpt_width]" name="<?php echo FT_RESPONSIVE_SLIDER_SETTINGS_FIELD; ?>[slideshow_excerpt_width]" value="<?php echo ft_get_responsive_slider_option( 'slideshow_excerpt_width' ); ?>" size="5" /></label>
-				</p>
-
-				<p>
-					<label for="<?php echo FT_RESPONSIVE_SLIDER_SETTINGS_FIELD; ?>[location_vertical]"><?php _e( 'Excerpt Location (vertical)', 'fortytwo' ); ?>:</label>
-					<select id="<?php echo FT_RESPONSIVE_SLIDER_SETTINGS_FIELD; ?>[location_vertical]" name="<?php echo FT_RESPONSIVE_SLIDER_SETTINGS_FIELD; ?>[location_vertical]">
-						<option style="padding-right:10px;" value="top" <?php selected( 'top', ft_get_responsive_slider_option( 'location_vertical' ) ); ?>><?php _e( 'Top', 'fortytwo' ); ?></option>
-						<option style="padding-right:10px;" value="bottom" <?php selected( 'bottom', ft_get_responsive_slider_option( 'location_vertical' ) ); ?>><?php _e( 'Bottom', 'fortytwo' ); ?></option>
-					</select>
-				</p>
-
-				<p>
-					<label for="<?php echo FT_RESPONSIVE_SLIDER_SETTINGS_FIELD; ?>[location_horizontal]"><?php _e( 'Excerpt Location (horizontal)', 'fortytwo' ); ?>:</label>
-					<select id="<?php echo FT_RESPONSIVE_SLIDER_SETTINGS_FIELD; ?>[location_horizontal]" name="<?php echo FT_RESPONSIVE_SLIDER_SETTINGS_FIELD; ?>[location_horizontal]">
-						<option style="padding-right:10px;" value="left" <?php selected( 'left', ft_get_responsive_slider_option( 'location_horizontal' ) ); ?>><?php _e( 'Left', 'fortytwo' ); ?></option>
-						<option style="padding-right:10px;" value="right" <?php selected( 'right', ft_get_responsive_slider_option( 'location_horizontal' ) ); ?>><?php _e( 'Right', 'fortytwo' ); ?></option>
-					</select>
 				</p>
 <?php
 }

--- a/lib/widgets/ft-responsive-slider/widget.php
+++ b/lib/widgets/ft-responsive-slider/widget.php
@@ -75,8 +75,6 @@ function ft_responsive_slider_sanitization() {
 			'slideshow_excerpt_content_limit',
 			'slideshow_more_text',
 			'slideshow_excerpt_width',
-			'location_vertical',
-			'location_horizontal',
 		) );
 }
 

--- a/style.css
+++ b/style.css
@@ -19,7 +19,6 @@
  * Designed and built with all the love in the world by @mdo and @fat.
  */
 /*! normalize.css v2.1.0 | MIT License | git.io/normalize */
-/* line 11, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 article,
 aside,
 details,
@@ -34,70 +33,56 @@ section,
 summary {
   display: block;
 }
-/* line 30, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 audio,
 canvas,
 video {
   display: inline-block;
 }
-/* line 41, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 audio:not([controls]) {
   display: none;
   height: 0;
 }
-/* line 50, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 [hidden] {
   display: none;
 }
-/* line 64, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 html {
   font-family: sans-serif;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
 }
-/* line 74, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 body {
   margin: 0;
 }
-/* line 86, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 a:focus {
   outline: thin dotted;
 }
-/* line 94, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 a:active,
 a:hover {
   outline: 0;
 }
-/* line 108, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 h1 {
   font-size: 2em;
   margin: 0.67em 0;
 }
-/* line 117, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 abbr[title] {
   border-bottom: 1px dotted;
 }
-/* line 125, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 b,
 strong {
   font-weight: bold;
 }
-/* line 134, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 dfn {
   font-style: italic;
 }
-/* line 142, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 hr {
   -moz-box-sizing: content-box;
   box-sizing: content-box;
   height: 0;
 }
-/* line 152, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 mark {
   background: #ff0;
   color: #000;
 }
-/* line 161, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 code,
 kbd,
 pre,
@@ -105,19 +90,15 @@ samp {
   font-family: monospace, serif;
   font-size: 1em;
 }
-/* line 173, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 pre {
   white-space: pre-wrap;
 }
-/* line 181, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 q {
   quotes: "\201C" "\201D" "\2018" "\2019";
 }
-/* line 189, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 small {
   font-size: 80%;
 }
-/* line 197, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 sub,
 sup {
   font-size: 75%;
@@ -125,38 +106,30 @@ sup {
   position: relative;
   vertical-align: baseline;
 }
-/* line 205, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 sup {
   top: -0.5em;
 }
-/* line 209, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 sub {
   bottom: -0.25em;
 }
-/* line 221, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 img {
   border: 0;
 }
-/* line 229, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 svg:not(:root) {
   overflow: hidden;
 }
-/* line 241, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 figure {
   margin: 0;
 }
-/* line 253, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 fieldset {
   border: 1px solid #c0c0c0;
   margin: 0 2px;
   padding: 0.35em 0.625em 0.75em;
 }
-/* line 264, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 legend {
   border: 0;
   padding: 0;
 }
-/* line 275, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 button,
 input,
 select,
@@ -165,17 +138,14 @@ textarea {
   font-size: 100%;
   margin: 0;
 }
-/* line 289, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 button,
 input {
   line-height: normal;
 }
-/* line 301, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 button,
 select {
   text-transform: none;
 }
-/* line 314, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 button,
 html input[type="button"],
 input[type="reset"],
@@ -183,138 +153,113 @@ input[type="submit"] {
   -webkit-appearance: button;
   cursor: pointer;
 }
-/* line 326, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 button[disabled],
 html input[disabled] {
   cursor: default;
 }
-/* line 336, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 input[type="checkbox"],
 input[type="radio"] {
   box-sizing: border-box;
   padding: 0;
 }
-/* line 348, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 input[type="search"] {
   -webkit-appearance: textfield;
   -moz-box-sizing: content-box;
   -webkit-box-sizing: content-box;
   box-sizing: content-box;
 }
-/* line 360, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 input[type="search"]::-webkit-search-cancel-button,
 input[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
-/* line 369, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 button::-moz-focus-inner,
 input::-moz-focus-inner {
   border: 0;
   padding: 0;
 }
-/* line 380, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 textarea {
   overflow: auto;
   vertical-align: top;
 }
-/* line 393, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/normalize.less */
 table {
   border-collapse: collapse;
   border-spacing: 0;
 }
 @media print {
-  /* line 8, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/print.less */
   * {
     text-shadow: none !important;
     color: #000 !important;
     background: transparent !important;
     box-shadow: none !important;
   }
-  /* line 15, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/print.less */
   a,
   a:visited {
     text-decoration: underline;
   }
-  /* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/print.less */
   a[href]:after {
     content: " (" attr(href) ")";
   }
-  /* line 24, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/print.less */
   abbr[title]:after {
     content: " (" attr(title) ")";
   }
-  /* line 29, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/print.less */
   .ir a:after,
   a[href^="javascript:"]:after,
   a[href^="#"]:after {
     content: "";
   }
-  /* line 35, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/print.less */
   pre,
   blockquote {
     border: 1px solid #999;
     page-break-inside: avoid;
   }
-  /* line 41, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/print.less */
   thead {
     display: table-header-group;
   }
-  /* line 45, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/print.less */
   tr,
   img {
     page-break-inside: avoid;
   }
-  /* line 50, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/print.less */
   img {
     max-width: 100% !important;
   }
   @page  {
     margin: 2cm .5cm;
   }
-  /* line 58, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/print.less */
   p,
   h2,
   h3 {
     orphans: 3;
     widows: 3;
   }
-  /* line 65, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/print.less */
   h2,
   h3 {
     page-break-after: avoid;
   }
-  /* line 71, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/print.less */
   .navbar {
     display: none;
   }
-  /* line 75, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/print.less */
   .table td,
   .table th,
   table td,
   table th {
     background-color: #fff !important;
   }
-  /* line 82, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/print.less */
   .btn > .caret,
   .dropup > .btn > .caret {
     border-top-color: #000 !important;
   }
-  /* line 86, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/print.less */
   .label {
     border: 1px solid #000;
   }
-  /* line 90, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/print.less */
   .table,
   table {
     border-collapse: collapse !important;
   }
-  /* line 94, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/print.less */
   .table-bordered th,
   .table-bordered td {
     border: 1px solid #ddd !important;
   }
 }
-/* line 8, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/scaffolding.less */
 *,
 *:before,
 *:after {
@@ -322,12 +267,10 @@ table {
   -moz-box-sizing: border-box;
   box-sizing: border-box;
 }
-/* line 17, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/scaffolding.less */
 html {
   font-size: 62.5%;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
-/* line 22, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/scaffolding.less */
 body {
   font-family: 'Open Sans', sans-serif;
   font-size: 14px;
@@ -335,7 +278,6 @@ body {
   color: #333333;
   background-color: #ffffff;
 }
-/* line 31, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/scaffolding.less */
 input,
 button,
 select,
@@ -344,45 +286,37 @@ textarea {
   font-size: inherit;
   line-height: inherit;
 }
-/* line 44, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/scaffolding.less */
 button,
 input,
 select[multiple],
 textarea {
   background-image: none;
 }
-/* line 54, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/scaffolding.less */
 a {
   color: #428bca;
   text-decoration: none;
 }
-/* line 58, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/scaffolding.less */
 a:hover,
 a:focus {
   color: #2a6496;
   text-decoration: underline;
 }
-/* line 64, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/scaffolding.less */
 a:focus {
   outline: thin dotted #333;
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }
-/* line 72, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/scaffolding.less */
 img {
   vertical-align: middle;
 }
-/* line 77, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/scaffolding.less */
 .img-responsive {
   display: block;
   max-width: 100%;
   height: auto;
 }
-/* line 82, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/scaffolding.less */
 .img-rounded {
   border-radius: 6px;
 }
-/* line 89, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/scaffolding.less */
 .img-thumbnail {
   padding: 4px;
   line-height: 1.428571429;
@@ -395,18 +329,15 @@ img {
   max-width: 100%;
   height: auto;
 }
-/* line 102, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/scaffolding.less */
 .img-circle {
   border-radius: 50%;
 }
-/* line 109, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/scaffolding.less */
 hr {
   margin-top: 20px;
   margin-bottom: 20px;
   border: 0;
   border-top: 1px solid #e8e8e8;
 }
-/* line 121, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/scaffolding.less */
 .sr-only {
   position: absolute;
   width: 1px;
@@ -417,11 +348,9 @@ hr {
   clip: rect(0 0 0 0);
   border: 0;
 }
-/* line 9, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 p {
   margin: 0 0 10px;
 }
-/* line 12, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 .lead {
   margin-bottom: 20px;
   font-size: 16.099999999999998px;
@@ -429,56 +358,43 @@ p {
   line-height: 1.4;
 }
 @media (min-width: 768px) {
-  /* line 18, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
   .lead {
     font-size: 21px;
   }
 }
-/* line 28, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 small {
   font-size: 85%;
 }
-/* line 31, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 cite {
   font-style: normal;
 }
-/* line 34, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 .text-muted {
   color: #999999;
 }
-/* line 35, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 .text-primary {
   color: #428bca;
 }
-/* line 36, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 .text-warning {
   color: #c09853;
 }
-/* line 37, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 .text-danger {
   color: #b94a48;
 }
-/* line 38, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 .text-success {
   color: #468847;
 }
-/* line 39, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 .text-info {
   color: #3a87ad;
 }
-/* line 42, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 .text-left {
   text-align: left;
 }
-/* line 43, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 .text-right {
   text-align: right;
 }
-/* line 44, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 .text-center {
   text-align: center;
 }
-/* line 50, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 h1,
 h2,
 h3,
@@ -495,7 +411,6 @@ h6,
   font-weight: 500;
   line-height: 1.1;
 }
-/* line 55, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 h1 small,
 h2 small,
 h3 small,
@@ -512,121 +427,99 @@ h6 small,
   line-height: 1;
   color: #999999;
 }
-/* line 62, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 h1,
 h2,
 h3 {
   margin-top: 20px;
   margin-bottom: 10px;
 }
-/* line 68, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 h4,
 h5,
 h6 {
   margin-top: 10px;
   margin-bottom: 10px;
 }
-/* line 75, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 h1,
 .h1 {
   font-size: 36px;
 }
-/* line 76, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 h2,
 .h2 {
   font-size: 30px;
 }
-/* line 77, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 h3,
 .h3 {
   font-size: 24px;
 }
-/* line 78, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 h4,
 .h4 {
   font-size: 18px;
 }
-/* line 79, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 h5,
 .h5 {
   font-size: 14px;
 }
-/* line 80, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 h6,
 .h6 {
   font-size: 12px;
 }
-/* line 82, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 h1 small,
 .h1 small {
   font-size: 24px;
 }
-/* line 83, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 h2 small,
 .h2 small {
   font-size: 18px;
 }
-/* line 84, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 h3 small,
 .h3 small,
 h4 small,
 .h4 small {
   font-size: 14px;
 }
-/* line 91, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 .page-header {
   padding-bottom: 9px;
   margin: 40px 0 20px;
   border-bottom: 1px solid #eeeeee;
 }
-/* line 103, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 ul,
 ol {
   margin-top: 0;
   margin-bottom: 10px;
 }
-/* line 107, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 ul ul,
 ol ul,
 ul ol,
 ol ol {
   margin-bottom: 0;
 }
-/* line 116, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 .list-unstyled {
   padding-left: 0;
   list-style: none;
 }
-/* line 121, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 .list-inline {
   padding-left: 0;
   list-style: none;
 }
-/* line 123, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 .list-inline > li {
   display: inline-block;
   padding-left: 5px;
   padding-right: 5px;
 }
-/* line 131, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 dl {
   margin-bottom: 20px;
 }
-/* line 134, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 dt,
 dd {
   line-height: 1.428571429;
 }
-/* line 138, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 dt {
   font-weight: bold;
 }
-/* line 141, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 dd {
   margin-left: 0;
 }
 @media (min-width: 768px) {
-  /* line 152, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
   .dl-horizontal dt {
     float: left;
     width: 160px;
@@ -636,11 +529,9 @@ dd {
     text-overflow: ellipsis;
     white-space: nowrap;
   }
-  /* line 159, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
   .dl-horizontal dd {
     margin-left: 180px;
   }
-  /* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   .dl-horizontal dd:before,
   .dl-horizontal dd:after {
     content: " ";
@@ -650,11 +541,9 @@ dd {
     /* 2 */
   
   }
-  /* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   .dl-horizontal dd:after {
     clear: both;
   }
-  /* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   .dl-horizontal dd:before,
   .dl-horizontal dd:after {
     content: " ";
@@ -664,88 +553,72 @@ dd {
     /* 2 */
   
   }
-  /* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   .dl-horizontal dd:after {
     clear: both;
   }
 }
-/* line 170, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 abbr[title],
 abbr[data-original-title] {
   cursor: help;
   border-bottom: 1px dotted #999999;
 }
-/* line 176, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 abbr.initialism {
   font-size: 90%;
   text-transform: uppercase;
 }
-/* line 182, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 blockquote {
   padding: 10px 20px;
   margin: 0 0 20px;
   border-left: 5px solid #eeeeee;
 }
-/* line 186, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 blockquote p {
   font-size: 17.5px;
   font-weight: 300;
   line-height: 1.25;
 }
-/* line 191, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 blockquote p:last-child {
   margin-bottom: 0;
 }
-/* line 194, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 blockquote small {
   display: block;
   line-height: 1.428571429;
   color: #999999;
 }
-/* line 198, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 blockquote small:before {
   content: '\2014 \00A0';
 }
-/* line 204, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 blockquote.pull-right {
   padding-right: 15px;
   padding-left: 0;
   border-right: 5px solid #eeeeee;
   border-left: 0;
 }
-/* line 209, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 blockquote.pull-right p,
 blockquote.pull-right small {
   text-align: right;
 }
-/* line 214, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 blockquote.pull-right small:before {
   content: '';
 }
-/* line 217, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 blockquote.pull-right small:after {
   content: '\00A0 \2014';
 }
-/* line 225, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 q:before,
 q:after,
 blockquote:before,
 blockquote:after {
   content: "";
 }
-/* line 233, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 address {
   display: block;
   margin-bottom: 20px;
   font-style: normal;
   line-height: 1.428571429;
 }
-/* line 7, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/code.less */
 code,
 pre {
   font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
 }
-/* line 13, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/code.less */
 code {
   padding: 2px 4px;
   font-size: 90%;
@@ -754,7 +627,6 @@ code {
   white-space: nowrap;
   border-radius: 4px;
 }
-/* line 23, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/code.less */
 pre {
   display: block;
   padding: 9.5px;
@@ -768,11 +640,9 @@ pre {
   border: 1px solid #cccccc;
   border-radius: 4px;
 }
-/* line 37, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/code.less */
 pre.prettyprint {
   margin-bottom: 20px;
 }
-/* line 42, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/code.less */
 pre code {
   padding: 0;
   font-size: inherit;
@@ -781,12 +651,10 @@ pre code {
   background-color: transparent;
   border: 0;
 }
-/* line 53, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/code.less */
 .pre-scrollable {
   max-height: 340px;
   overflow-y: scroll;
 }
-/* line 7, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
 .container,
 .wrap {
   margin-right: auto;
@@ -794,7 +662,6 @@ pre code {
   padding-left: 15px;
   padding-right: 15px;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .container:before,
 .container:after,
 .wrap:before,
@@ -806,12 +673,10 @@ pre code {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .container:after,
 .wrap:after {
   clear: both;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .container:before,
 .container:after,
 .wrap:before,
@@ -823,19 +688,16 @@ pre code {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .container:after,
 .wrap:after {
   clear: both;
 }
-/* line 12, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
 .row,
 .inner-wrap,
 .content > .section-container {
   margin-left: -15px;
   margin-right: -15px;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .row:before,
 .row:after,
 .inner-wrap:before,
@@ -849,13 +711,11 @@ pre code {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .row:after,
 .inner-wrap:after,
 .content > .section-container:after {
   clear: both;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .row:before,
 .row:after,
 .inner-wrap:before,
@@ -869,13 +729,11 @@ pre code {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .row:after,
 .inner-wrap:after,
 .content > .section-container:after {
   clear: both;
 }
-/* line 17, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
 .col-xs-1,
 .col-xs-2,
 .col-xs-3,
@@ -929,7 +787,6 @@ pre code {
   padding-left: 15px;
   padding-right: 15px;
 }
-/* line 82, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
 .col-xs-1,
 .col-xs-2,
 .col-xs-3,
@@ -943,61 +800,47 @@ pre code {
 .col-xs-11 {
   float: left;
 }
-/* line 95, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
 .col-xs-1 {
   width: 8.333333333333332%;
 }
-/* line 96, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
 .col-xs-2 {
   width: 16.666666666666664%;
 }
-/* line 97, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
 .col-xs-3 {
   width: 25%;
 }
-/* line 98, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
 .col-xs-4 {
   width: 33.33333333333333%;
 }
-/* line 99, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
 .col-xs-5 {
   width: 41.66666666666667%;
 }
-/* line 100, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
 .col-xs-6 {
   width: 50%;
 }
-/* line 101, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
 .col-xs-7 {
   width: 58.333333333333336%;
 }
-/* line 102, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
 .col-xs-8 {
   width: 66.66666666666666%;
 }
-/* line 103, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
 .col-xs-9 {
   width: 75%;
 }
-/* line 104, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
 .col-xs-10 {
   width: 83.33333333333334%;
 }
-/* line 105, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
 .col-xs-11 {
   width: 91.66666666666666%;
 }
-/* line 106, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
 .col-xs-12 {
   width: 100%;
 }
 @media (min-width: 768px) {
-  /* line 118, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .container,
   .wrap {
     max-width: 750px;
   }
-  /* line 122, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-1,
   .col-sm-2,
   .col-sm-3,
@@ -1011,194 +854,147 @@ pre code {
   .col-sm-11 {
     float: left;
   }
-  /* line 135, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-1 {
     width: 8.333333333333332%;
   }
-  /* line 136, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-2 {
     width: 16.666666666666664%;
   }
-  /* line 137, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-3 {
     width: 25%;
   }
-  /* line 138, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-4 {
     width: 33.33333333333333%;
   }
-  /* line 139, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-5 {
     width: 41.66666666666667%;
   }
-  /* line 140, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-6 {
     width: 50%;
   }
-  /* line 141, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-7 {
     width: 58.333333333333336%;
   }
-  /* line 142, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-8 {
     width: 66.66666666666666%;
   }
-  /* line 143, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-9 {
     width: 75%;
   }
-  /* line 144, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-10 {
     width: 83.33333333333334%;
   }
-  /* line 145, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-11 {
     width: 91.66666666666666%;
   }
-  /* line 146, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-12 {
     width: 100%;
   }
-  /* line 149, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-push-1 {
     left: 8.333333333333332%;
   }
-  /* line 150, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-push-2 {
     left: 16.666666666666664%;
   }
-  /* line 151, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-push-3 {
     left: 25%;
   }
-  /* line 152, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-push-4 {
     left: 33.33333333333333%;
   }
-  /* line 153, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-push-5 {
     left: 41.66666666666667%;
   }
-  /* line 154, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-push-6 {
     left: 50%;
   }
-  /* line 155, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-push-7 {
     left: 58.333333333333336%;
   }
-  /* line 156, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-push-8 {
     left: 66.66666666666666%;
   }
-  /* line 157, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-push-9 {
     left: 75%;
   }
-  /* line 158, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-push-10 {
     left: 83.33333333333334%;
   }
-  /* line 159, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-push-11 {
     left: 91.66666666666666%;
   }
-  /* line 161, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-pull-1 {
     right: 8.333333333333332%;
   }
-  /* line 162, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-pull-2 {
     right: 16.666666666666664%;
   }
-  /* line 163, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-pull-3 {
     right: 25%;
   }
-  /* line 164, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-pull-4 {
     right: 33.33333333333333%;
   }
-  /* line 165, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-pull-5 {
     right: 41.66666666666667%;
   }
-  /* line 166, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-pull-6 {
     right: 50%;
   }
-  /* line 167, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-pull-7 {
     right: 58.333333333333336%;
   }
-  /* line 168, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-pull-8 {
     right: 66.66666666666666%;
   }
-  /* line 169, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-pull-9 {
     right: 75%;
   }
-  /* line 170, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-pull-10 {
     right: 83.33333333333334%;
   }
-  /* line 171, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-pull-11 {
     right: 91.66666666666666%;
   }
-  /* line 174, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-offset-1 {
     margin-left: 8.333333333333332%;
   }
-  /* line 175, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-offset-2 {
     margin-left: 16.666666666666664%;
   }
-  /* line 176, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-offset-3 {
     margin-left: 25%;
   }
-  /* line 177, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-offset-4 {
     margin-left: 33.33333333333333%;
   }
-  /* line 178, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-offset-5 {
     margin-left: 41.66666666666667%;
   }
-  /* line 179, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-offset-6 {
     margin-left: 50%;
   }
-  /* line 180, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-offset-7 {
     margin-left: 58.333333333333336%;
   }
-  /* line 181, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-offset-8 {
     margin-left: 66.66666666666666%;
   }
-  /* line 182, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-offset-9 {
     margin-left: 75%;
   }
-  /* line 183, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-offset-10 {
     margin-left: 83.33333333333334%;
   }
-  /* line 184, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-sm-offset-11 {
     margin-left: 91.66666666666666%;
   }
 }
 @media (min-width: 992px) {
-  /* line 196, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .container,
   .wrap {
     max-width: 970px;
   }
-  /* line 199, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-1,
   .col-md-2,
   .col-md-3,
@@ -1212,206 +1008,156 @@ pre code {
   .col-md-11 {
     float: left;
   }
-  /* line 212, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-1 {
     width: 8.333333333333332%;
   }
-  /* line 213, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-2 {
     width: 16.666666666666664%;
   }
-  /* line 214, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-3 {
     width: 25%;
   }
-  /* line 215, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-4 {
     width: 33.33333333333333%;
   }
-  /* line 216, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-5 {
     width: 41.66666666666667%;
   }
-  /* line 217, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-6 {
     width: 50%;
   }
-  /* line 218, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-7 {
     width: 58.333333333333336%;
   }
-  /* line 219, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-8 {
     width: 66.66666666666666%;
   }
-  /* line 220, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-9 {
     width: 75%;
   }
-  /* line 221, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-10 {
     width: 83.33333333333334%;
   }
-  /* line 222, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-11 {
     width: 91.66666666666666%;
   }
-  /* line 223, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-12 {
     width: 100%;
   }
-  /* line 226, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-push-0 {
     left: auto;
   }
-  /* line 227, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-push-1 {
     left: 8.333333333333332%;
   }
-  /* line 228, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-push-2 {
     left: 16.666666666666664%;
   }
-  /* line 229, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-push-3 {
     left: 25%;
   }
-  /* line 230, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-push-4 {
     left: 33.33333333333333%;
   }
-  /* line 231, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-push-5 {
     left: 41.66666666666667%;
   }
-  /* line 232, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-push-6 {
     left: 50%;
   }
-  /* line 233, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-push-7 {
     left: 58.333333333333336%;
   }
-  /* line 234, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-push-8 {
     left: 66.66666666666666%;
   }
-  /* line 235, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-push-9 {
     left: 75%;
   }
-  /* line 236, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-push-10 {
     left: 83.33333333333334%;
   }
-  /* line 237, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-push-11 {
     left: 91.66666666666666%;
   }
-  /* line 239, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-pull-0 {
     right: auto;
   }
-  /* line 240, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-pull-1 {
     right: 8.333333333333332%;
   }
-  /* line 241, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-pull-2 {
     right: 16.666666666666664%;
   }
-  /* line 242, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-pull-3 {
     right: 25%;
   }
-  /* line 243, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-pull-4 {
     right: 33.33333333333333%;
   }
-  /* line 244, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-pull-5 {
     right: 41.66666666666667%;
   }
-  /* line 245, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-pull-6 {
     right: 50%;
   }
-  /* line 246, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-pull-7 {
     right: 58.333333333333336%;
   }
-  /* line 247, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-pull-8 {
     right: 66.66666666666666%;
   }
-  /* line 248, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-pull-9 {
     right: 75%;
   }
-  /* line 249, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-pull-10 {
     right: 83.33333333333334%;
   }
-  /* line 250, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-pull-11 {
     right: 91.66666666666666%;
   }
-  /* line 253, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-offset-0 {
     margin-left: 0;
   }
-  /* line 254, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-offset-1 {
     margin-left: 8.333333333333332%;
   }
-  /* line 255, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-offset-2 {
     margin-left: 16.666666666666664%;
   }
-  /* line 256, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-offset-3 {
     margin-left: 25%;
   }
-  /* line 257, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-offset-4 {
     margin-left: 33.33333333333333%;
   }
-  /* line 258, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-offset-5 {
     margin-left: 41.66666666666667%;
   }
-  /* line 259, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-offset-6 {
     margin-left: 50%;
   }
-  /* line 260, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-offset-7 {
     margin-left: 58.333333333333336%;
   }
-  /* line 261, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-offset-8 {
     margin-left: 66.66666666666666%;
   }
-  /* line 262, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-offset-9 {
     margin-left: 75%;
   }
-  /* line 263, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-offset-10 {
     margin-left: 83.33333333333334%;
   }
-  /* line 264, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-md-offset-11 {
     margin-left: 91.66666666666666%;
   }
 }
 @media (min-width: 1200px) {
-  /* line 276, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .container,
   .wrap {
     max-width: 1170px;
   }
-  /* line 280, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-1,
   .col-lg-2,
   .col-lg-3,
@@ -1425,215 +1171,163 @@ pre code {
   .col-lg-11 {
     float: left;
   }
-  /* line 293, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-1 {
     width: 8.333333333333332%;
   }
-  /* line 294, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-2 {
     width: 16.666666666666664%;
   }
-  /* line 295, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-3 {
     width: 25%;
   }
-  /* line 296, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-4 {
     width: 33.33333333333333%;
   }
-  /* line 297, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-5 {
     width: 41.66666666666667%;
   }
-  /* line 298, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-6 {
     width: 50%;
   }
-  /* line 299, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-7 {
     width: 58.333333333333336%;
   }
-  /* line 300, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-8 {
     width: 66.66666666666666%;
   }
-  /* line 301, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-9 {
     width: 75%;
   }
-  /* line 302, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-10 {
     width: 83.33333333333334%;
   }
-  /* line 303, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-11 {
     width: 91.66666666666666%;
   }
-  /* line 304, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-12 {
     width: 100%;
   }
-  /* line 307, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-push-0 {
     left: auto;
   }
-  /* line 308, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-push-1 {
     left: 8.333333333333332%;
   }
-  /* line 309, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-push-2 {
     left: 16.666666666666664%;
   }
-  /* line 310, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-push-3 {
     left: 25%;
   }
-  /* line 311, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-push-4 {
     left: 33.33333333333333%;
   }
-  /* line 312, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-push-5 {
     left: 41.66666666666667%;
   }
-  /* line 313, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-push-6 {
     left: 50%;
   }
-  /* line 314, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-push-7 {
     left: 58.333333333333336%;
   }
-  /* line 315, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-push-8 {
     left: 66.66666666666666%;
   }
-  /* line 316, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-push-9 {
     left: 75%;
   }
-  /* line 317, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-push-10 {
     left: 83.33333333333334%;
   }
-  /* line 318, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-push-11 {
     left: 91.66666666666666%;
   }
-  /* line 320, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-pull-0 {
     right: auto;
   }
-  /* line 321, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-pull-1 {
     right: 8.333333333333332%;
   }
-  /* line 322, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-pull-2 {
     right: 16.666666666666664%;
   }
-  /* line 323, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-pull-3 {
     right: 25%;
   }
-  /* line 324, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-pull-4 {
     right: 33.33333333333333%;
   }
-  /* line 325, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-pull-5 {
     right: 41.66666666666667%;
   }
-  /* line 326, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-pull-6 {
     right: 50%;
   }
-  /* line 327, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-pull-7 {
     right: 58.333333333333336%;
   }
-  /* line 328, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-pull-8 {
     right: 66.66666666666666%;
   }
-  /* line 329, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-pull-9 {
     right: 75%;
   }
-  /* line 330, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-pull-10 {
     right: 83.33333333333334%;
   }
-  /* line 331, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-pull-11 {
     right: 91.66666666666666%;
   }
-  /* line 334, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-offset-0 {
     margin-left: 0;
   }
-  /* line 335, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-offset-1 {
     margin-left: 8.333333333333332%;
   }
-  /* line 336, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-offset-2 {
     margin-left: 16.666666666666664%;
   }
-  /* line 337, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-offset-3 {
     margin-left: 25%;
   }
-  /* line 338, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-offset-4 {
     margin-left: 33.33333333333333%;
   }
-  /* line 339, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-offset-5 {
     margin-left: 41.66666666666667%;
   }
-  /* line 340, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-offset-6 {
     margin-left: 50%;
   }
-  /* line 341, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-offset-7 {
     margin-left: 58.333333333333336%;
   }
-  /* line 342, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-offset-8 {
     margin-left: 66.66666666666666%;
   }
-  /* line 343, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-offset-9 {
     margin-left: 75%;
   }
-  /* line 344, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-offset-10 {
     margin-left: 83.33333333333334%;
   }
-  /* line 345, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/grid.less */
   .col-lg-offset-11 {
     margin-left: 91.66666666666666%;
   }
 }
-/* line 6, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tables.less */
 table {
   max-width: 100%;
   background-color: transparent;
 }
-/* line 10, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tables.less */
 th {
   text-align: left;
 }
-/* line 17, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tables.less */
 .table,
 table {
   width: 100%;
   margin-bottom: 20px;
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tables.less */
 .table thead > tr > th,
 .table tbody > tr > th,
 .table tfoot > tr > th,
@@ -1651,13 +1345,11 @@ table tfoot > tr > td {
   vertical-align: top;
   border-top: 1px solid #e8e8e8;
 }
-/* line 35, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tables.less */
 .table thead > tr > th,
 table thead > tr > th {
   vertical-align: bottom;
   border-bottom: 2px solid #e8e8e8;
 }
-/* line 44, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tables.less */
 .table caption + thead tr:first-child th,
 .table colgroup + thead tr:first-child th,
 .table thead:first-child tr:first-child th,
@@ -1672,17 +1364,14 @@ table colgroup + thead tr:first-child td,
 table thead:first-child tr:first-child td {
   border-top: 0;
 }
-/* line 50, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tables.less */
 .table tbody + tbody,
 table tbody + tbody {
   border-top: 2px solid #e8e8e8;
 }
-/* line 55, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tables.less */
 .table .table,
 table table {
   background-color: #ffffff;
 }
-/* line 68, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tables.less */
 .table-condensed thead > tr > th,
 .table-condensed tbody > tr > th,
 .table-condensed tfoot > tr > th,
@@ -1691,11 +1380,9 @@ table table {
 .table-condensed tfoot > tr > td {
   padding: 5px;
 }
-/* line 81, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tables.less */
 .table-bordered {
   border: 1px solid #e8e8e8;
 }
-/* line 87, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tables.less */
 .table-bordered > thead > tr > th,
 .table-bordered > tbody > tr > th,
 .table-bordered > tfoot > tr > th,
@@ -1704,33 +1391,27 @@ table table {
 .table-bordered > tfoot > tr > td {
   border: 1px solid #e8e8e8;
 }
-/* line 95, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tables.less */
 .table-bordered > thead > tr > th,
 .table-bordered > thead > tr > td {
   border-bottom-width: 2px;
 }
-/* line 111, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tables.less */
 .table-striped > tbody > tr:nth-child(odd) > td,
 .table-striped > tbody > tr:nth-child(odd) > th {
   background-color: #fafafa;
 }
-/* line 127, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tables.less */
 .table-hover > tbody > tr:hover > td,
 .table-hover > tbody > tr:hover > th {
   background-color: #f5f5f5;
 }
-/* line 140, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tables.less */
 table col[class*="col-"] {
   float: none;
   display: table-column;
 }
-/* line 147, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tables.less */
 table td[class*="col-"],
 table th[class*="col-"] {
   float: none;
   display: table-cell;
 }
-/* line 163, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tables.less */
 .table > thead > tr > td.active,
 .table > tbody > tr > td.active,
 .table > tfoot > tr > td.active,
@@ -1757,7 +1438,6 @@ table > tbody > tr.active > th,
 table > tfoot > tr.active > th {
   background-color: #f5f5f5;
 }
-/* line 382, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .table > thead > tr > td.success,
 .table > tbody > tr > td.success,
 .table > tfoot > tr > td.success,
@@ -1785,14 +1465,12 @@ table > tfoot > tr.success > th {
   background-color: #dff0d8;
   border-color: #d6e9c6;
 }
-/* line 394, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .table-hover > tbody > tr > td.success:hover,
 .table-hover > tbody > tr > th.success:hover,
 .table-hover > tbody > tr.success:hover > td {
   background-color: #d0e9c6;
   border-color: #c9e2b3;
 }
-/* line 382, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .table > thead > tr > td.danger,
 .table > tbody > tr > td.danger,
 .table > tfoot > tr > td.danger,
@@ -1820,14 +1498,12 @@ table > tfoot > tr.danger > th {
   background-color: #f2dede;
   border-color: #eed3d7;
 }
-/* line 394, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .table-hover > tbody > tr > td.danger:hover,
 .table-hover > tbody > tr > th.danger:hover,
 .table-hover > tbody > tr.danger:hover > td {
   background-color: #ebcccc;
   border-color: #e6c1c7;
 }
-/* line 382, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .table > thead > tr > td.warning,
 .table > tbody > tr > td.warning,
 .table > tfoot > tr > td.warning,
@@ -1855,7 +1531,6 @@ table > tfoot > tr.warning > th {
   background-color: #fcf8e3;
   border-color: #fbeed5;
 }
-/* line 394, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .table-hover > tbody > tr > td.warning:hover,
 .table-hover > tbody > tr > th.warning:hover,
 .table-hover > tbody > tr.warning:hover > td {
@@ -1863,7 +1538,6 @@ table > tfoot > tr.warning > th {
   border-color: #f8e5be;
 }
 @media (max-width: 768px) {
-  /* line 184, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tables.less */
   .table-responsive {
     width: 100%;
     margin-bottom: 15px;
@@ -1871,13 +1545,11 @@ table > tfoot > tr.warning > th {
     overflow-x: scroll;
     border: 1px solid #e8e8e8;
   }
-  /* line 192, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tables.less */
   .table-responsive > .table,
   .table-responsive > table {
     margin-bottom: 0;
     background-color: #fff;
   }
-  /* line 201, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tables.less */
   .table-responsive > .table > thead > tr > th,
   .table-responsive > .table > tbody > tr > th,
   .table-responsive > .table > tfoot > tr > th,
@@ -1892,11 +1564,9 @@ table > tfoot > tr.warning > th {
   .table-responsive > table > tfoot > tr > td {
     white-space: nowrap;
   }
-  /* line 210, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tables.less */
   .table-responsive > .table-bordered {
     border: 0;
   }
-  /* line 218, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tables.less */
   .table-responsive > .table-bordered > thead > tr > th:first-child,
   .table-responsive > .table-bordered > tbody > tr > th:first-child,
   .table-responsive > .table-bordered > tfoot > tr > th:first-child,
@@ -1905,7 +1575,6 @@ table > tfoot > tr.warning > th {
   .table-responsive > .table-bordered > tfoot > tr > td:first-child {
     border-left: 0;
   }
-  /* line 222, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tables.less */
   .table-responsive > .table-bordered > thead > tr > th:last-child,
   .table-responsive > .table-bordered > tbody > tr > th:last-child,
   .table-responsive > .table-bordered > tfoot > tr > th:last-child,
@@ -1914,7 +1583,6 @@ table > tfoot > tr.warning > th {
   .table-responsive > .table-bordered > tfoot > tr > td:last-child {
     border-right: 0;
   }
-  /* line 228, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tables.less */
   .table-responsive > .table-bordered > thead > tr:last-child > th,
   .table-responsive > .table-bordered > tbody > tr:last-child > th,
   .table-responsive > .table-bordered > tfoot > tr:last-child > th,
@@ -1924,13 +1592,11 @@ table > tfoot > tr.warning > th {
     border-bottom: 0;
   }
 }
-/* line 10, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
 fieldset {
   padding: 0;
   margin: 0;
   border: 0;
 }
-/* line 16, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
 legend {
   display: block;
   width: 100%;
@@ -1942,19 +1608,16 @@ legend {
   border: 0;
   border-bottom: 1px solid #e5e5e5;
 }
-/* line 28, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
 label {
   display: inline-block;
   margin-bottom: 5px;
   font-weight: bold;
 }
-/* line 38, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
 input[type="search"] {
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
 }
-/* line 43, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
 input[type="radio"],
 input[type="checkbox"] {
   margin: 4px 0 0;
@@ -1963,22 +1626,18 @@ input[type="checkbox"] {
 
   line-height: normal;
 }
-/* line 51, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
 input[type="file"] {
   display: block;
 }
-/* line 56, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
 select[multiple],
 select[size] {
   height: auto;
 }
-/* line 62, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
 select optgroup {
   font-size: inherit;
   font-style: inherit;
   font-family: inherit;
 }
-/* line 69, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
 input[type="file"]:focus,
 input[type="radio"]:focus,
 input[type="checkbox"]:focus {
@@ -1986,28 +1645,22 @@ input[type="checkbox"]:focus {
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }
-/* line 79, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
 input[type="number"]::-webkit-outer-spin-button,
 input[type="number"]::-webkit-inner-spin-button {
   height: auto;
 }
-/* line 57, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .form-control:-moz-placeholder {
   color: #999999;
 }
-/* line 58, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .form-control::-moz-placeholder {
   color: #999999;
 }
-/* line 59, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .form-control:-ms-input-placeholder {
   color: #999999;
 }
-/* line 60, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .form-control::-webkit-input-placeholder {
   color: #999999;
 }
-/* line 117, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
 .form-control {
   display: block;
   width: 100%;
@@ -2025,29 +1678,24 @@ input[type="number"]::-webkit-inner-spin-button {
   -webkit-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
   transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
 }
-/* line 695, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .form-control:focus {
   border-color: #66afe9;
   outline: 0;
   -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102, 175, 233, 0.6);
   box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102, 175, 233, 0.6);
 }
-/* line 139, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
 .form-control[disabled],
 .form-control[readonly],
 fieldset[disabled] .form-control {
   cursor: not-allowed;
   background-color: #eeeeee;
 }
-/* line 147, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
 textarea.form-control {
   height: auto;
 }
-/* line 158, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
 .form-group {
   margin-bottom: 15px;
 }
-/* line 167, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
 .radio,
 .checkbox {
   display: block;
@@ -2057,7 +1705,6 @@ textarea.form-control {
   padding-left: 20px;
   vertical-align: middle;
 }
-/* line 175, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
 .radio label,
 .checkbox label {
   display: inline;
@@ -2065,7 +1712,6 @@ textarea.form-control {
   font-weight: normal;
   cursor: pointer;
 }
-/* line 182, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
 .radio input[type="radio"],
 .radio-inline input[type="radio"],
 .checkbox input[type="checkbox"],
@@ -2073,12 +1719,10 @@ textarea.form-control {
   float: left;
   margin-left: -20px;
 }
-/* line 189, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
 .radio + .radio,
 .checkbox + .checkbox {
   margin-top: -5px;
 }
-/* line 195, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
 .radio-inline,
 .checkbox-inline {
   display: inline-block;
@@ -2088,13 +1732,11 @@ textarea.form-control {
   font-weight: normal;
   cursor: pointer;
 }
-/* line 204, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
 .radio-inline + .radio-inline,
 .checkbox-inline + .checkbox-inline {
   margin-top: 0;
   margin-left: 10px;
 }
-/* line 219, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
 input[type="radio"][disabled],
 input[type="checkbox"][disabled],
 .radio[disabled],
@@ -2109,7 +1751,6 @@ fieldset[disabled] .checkbox,
 fieldset[disabled] .checkbox-inline {
   cursor: not-allowed;
 }
-/* line 226, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
 .input-sm {
   height: 30px;
   padding: 5px 10px;
@@ -2117,16 +1758,13 @@ fieldset[disabled] .checkbox-inline {
   line-height: 1.5;
   border-radius: 3px;
 }
-/* line 715, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 select.input-sm {
   height: 30px;
   line-height: 30px;
 }
-/* line 720, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 textarea.input-sm {
   height: auto;
 }
-/* line 230, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
 .input-lg {
   height: 45px;
   padding: 10px 16px;
@@ -2134,90 +1772,74 @@ textarea.input-sm {
   line-height: 1.33;
   border-radius: 6px;
 }
-/* line 715, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 select.input-lg {
   height: 45px;
   line-height: 45px;
 }
-/* line 720, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 textarea.input-lg {
   height: auto;
 }
-/* line 658, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .has-warning .help-block,
 .has-warning .control-label {
   color: #c09853;
 }
-/* line 663, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .has-warning .form-control {
   border-color: #c09853;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
 }
-/* line 666, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .has-warning .form-control:focus {
   border-color: #a47e3c;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #dbc59e;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #dbc59e;
 }
-/* line 673, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .has-warning .input-group-addon {
   color: #c09853;
   border-color: #c09853;
   background-color: #fcf8e3;
 }
-/* line 658, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .has-error .help-block,
 .has-error .control-label {
   color: #b94a48;
 }
-/* line 663, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .has-error .form-control {
   border-color: #b94a48;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
 }
-/* line 666, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .has-error .form-control:focus {
   border-color: #953b39;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #d59392;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #d59392;
 }
-/* line 673, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .has-error .input-group-addon {
   color: #b94a48;
   border-color: #b94a48;
   background-color: #f2dede;
 }
-/* line 658, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .has-success .help-block,
 .has-success .control-label {
   color: #468847;
 }
-/* line 663, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .has-success .form-control {
   border-color: #468847;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
 }
-/* line 666, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .has-success .form-control:focus {
   border-color: #356635;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #7aba7b;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #7aba7b;
 }
-/* line 673, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .has-success .input-group-addon {
   color: #468847;
   border-color: #468847;
   background-color: #dff0d8;
 }
-/* line 258, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
 .form-control-static {
   margin-bottom: 0;
   padding-top: 7px;
 }
-/* line 269, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
 .help-block {
   display: block;
   margin-top: 5px;
@@ -2225,17 +1847,14 @@ textarea.input-lg {
   color: #737373;
 }
 @media (min-width: 768px) {
-  /* line 294, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
   .form-inline .form-group {
     display: inline-block;
     margin-bottom: 0;
     vertical-align: middle;
   }
-  /* line 301, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
   .form-inline .form-control {
     display: inline-block;
   }
-  /* line 308, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
   .form-inline .radio,
   .form-inline .checkbox {
     display: inline-block;
@@ -2243,14 +1862,12 @@ textarea.input-lg {
     margin-bottom: 0;
     padding-left: 0;
   }
-  /* line 315, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
   .form-inline .radio input[type="radio"],
   .form-inline .checkbox input[type="checkbox"] {
     float: none;
     margin-left: 0;
   }
 }
-/* line 332, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
 .form-horizontal .control-label,
 .form-horizontal .radio,
 .form-horizontal .checkbox,
@@ -2260,12 +1877,10 @@ textarea.input-lg {
   margin-bottom: 0;
   padding-top: 7px;
 }
-/* line 343, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
 .form-horizontal .form-group {
   margin-left: -15px;
   margin-right: -15px;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .form-horizontal .form-group:before,
 .form-horizontal .form-group:after {
   content: " ";
@@ -2275,11 +1890,9 @@ textarea.input-lg {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .form-horizontal .form-group:after {
   clear: both;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .form-horizontal .form-group:before,
 .form-horizontal .form-group:after {
   content: " ";
@@ -2289,17 +1902,14 @@ textarea.input-lg {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .form-horizontal .form-group:after {
   clear: both;
 }
 @media (min-width: 768px) {
-  /* line 349, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
   .form-horizontal .control-label {
     text-align: right;
   }
 }
-/* line 10, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/buttons.less */
 .btn {
   display: inline-block;
   padding: 6px 12px;
@@ -2319,19 +1929,16 @@ textarea.input-lg {
   -o-user-select: none;
   user-select: none;
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/buttons.less */
 .btn:focus {
   outline: thin dotted #333;
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }
-/* line 29, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/buttons.less */
 .btn:hover,
 .btn:focus {
   color: #333333;
   text-decoration: none;
 }
-/* line 35, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/buttons.less */
 .btn:active,
 .btn.active {
   outline: 0;
@@ -2339,7 +1946,6 @@ textarea.input-lg {
   -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
 }
-/* line 42, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/buttons.less */
 .btn.disabled,
 .btn[disabled],
 fieldset[disabled] .btn {
@@ -2350,13 +1956,11 @@ fieldset[disabled] .btn {
   -webkit-box-shadow: none;
   box-shadow: none;
 }
-/* line 57, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/buttons.less */
 .btn-default {
   color: #333333;
   background-color: #ffffff;
   border-color: #cccccc;
 }
-/* line 412, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .btn-default:hover,
 .btn-default:focus,
 .btn-default:active,
@@ -2366,13 +1970,11 @@ fieldset[disabled] .btn {
   background-color: #ebebeb;
   border-color: #adadad;
 }
-/* line 421, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .btn-default:active,
 .btn-default.active,
 .open .dropdown-toggle.btn-default {
   background-image: none;
 }
-/* line 429, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .btn-default.disabled,
 .btn-default[disabled],
 fieldset[disabled] .btn-default,
@@ -2391,13 +1993,11 @@ fieldset[disabled] .btn-default.active {
   background-color: #ffffff;
   border-color: #cccccc;
 }
-/* line 60, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/buttons.less */
 .btn-primary {
   color: #ffffff;
   background-color: #428bca;
   border-color: #357ebd;
 }
-/* line 412, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .btn-primary:hover,
 .btn-primary:focus,
 .btn-primary:active,
@@ -2407,13 +2007,11 @@ fieldset[disabled] .btn-default.active {
   background-color: #3276b1;
   border-color: #285e8e;
 }
-/* line 421, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .btn-primary:active,
 .btn-primary.active,
 .open .dropdown-toggle.btn-primary {
   background-image: none;
 }
-/* line 429, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .btn-primary.disabled,
 .btn-primary[disabled],
 fieldset[disabled] .btn-primary,
@@ -2432,13 +2030,11 @@ fieldset[disabled] .btn-primary.active {
   background-color: #428bca;
   border-color: #357ebd;
 }
-/* line 64, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/buttons.less */
 .btn-warning {
   color: #ffffff;
   background-color: #f0ad4e;
   border-color: #eea236;
 }
-/* line 412, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .btn-warning:hover,
 .btn-warning:focus,
 .btn-warning:active,
@@ -2448,13 +2044,11 @@ fieldset[disabled] .btn-primary.active {
   background-color: #ed9c28;
   border-color: #d58512;
 }
-/* line 421, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .btn-warning:active,
 .btn-warning.active,
 .open .dropdown-toggle.btn-warning {
   background-image: none;
 }
-/* line 429, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .btn-warning.disabled,
 .btn-warning[disabled],
 fieldset[disabled] .btn-warning,
@@ -2473,13 +2067,11 @@ fieldset[disabled] .btn-warning.active {
   background-color: #f0ad4e;
   border-color: #eea236;
 }
-/* line 68, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/buttons.less */
 .btn-danger {
   color: #ffffff;
   background-color: #d9534f;
   border-color: #d43f3a;
 }
-/* line 412, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .btn-danger:hover,
 .btn-danger:focus,
 .btn-danger:active,
@@ -2489,13 +2081,11 @@ fieldset[disabled] .btn-warning.active {
   background-color: #d2322d;
   border-color: #ac2925;
 }
-/* line 421, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .btn-danger:active,
 .btn-danger.active,
 .open .dropdown-toggle.btn-danger {
   background-image: none;
 }
-/* line 429, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .btn-danger.disabled,
 .btn-danger[disabled],
 fieldset[disabled] .btn-danger,
@@ -2514,13 +2104,11 @@ fieldset[disabled] .btn-danger.active {
   background-color: #d9534f;
   border-color: #d43f3a;
 }
-/* line 72, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/buttons.less */
 .btn-success {
   color: #ffffff;
   background-color: #5cb85c;
   border-color: #4cae4c;
 }
-/* line 412, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .btn-success:hover,
 .btn-success:focus,
 .btn-success:active,
@@ -2530,13 +2118,11 @@ fieldset[disabled] .btn-danger.active {
   background-color: #47a447;
   border-color: #398439;
 }
-/* line 421, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .btn-success:active,
 .btn-success.active,
 .open .dropdown-toggle.btn-success {
   background-image: none;
 }
-/* line 429, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .btn-success.disabled,
 .btn-success[disabled],
 fieldset[disabled] .btn-success,
@@ -2555,13 +2141,11 @@ fieldset[disabled] .btn-success.active {
   background-color: #5cb85c;
   border-color: #4cae4c;
 }
-/* line 76, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/buttons.less */
 .btn-info {
   color: #ffffff;
   background-color: #5bc0de;
   border-color: #46b8da;
 }
-/* line 412, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .btn-info:hover,
 .btn-info:focus,
 .btn-info:active,
@@ -2571,13 +2155,11 @@ fieldset[disabled] .btn-success.active {
   background-color: #39b3d7;
   border-color: #269abc;
 }
-/* line 421, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .btn-info:active,
 .btn-info.active,
 .open .dropdown-toggle.btn-info {
   background-image: none;
 }
-/* line 429, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .btn-info.disabled,
 .btn-info[disabled],
 fieldset[disabled] .btn-info,
@@ -2596,14 +2178,12 @@ fieldset[disabled] .btn-info.active {
   background-color: #5bc0de;
   border-color: #46b8da;
 }
-/* line 85, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/buttons.less */
 .btn-link {
   color: #428bca;
   font-weight: normal;
   cursor: pointer;
   border-radius: 0;
 }
-/* line 91, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/buttons.less */
 .btn-link,
 .btn-link:active,
 .btn-link[disabled],
@@ -2612,21 +2192,18 @@ fieldset[disabled] .btn-link {
   -webkit-box-shadow: none;
   box-shadow: none;
 }
-/* line 98, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/buttons.less */
 .btn-link,
 .btn-link:hover,
 .btn-link:focus,
 .btn-link:active {
   border-color: transparent;
 }
-/* line 104, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/buttons.less */
 .btn-link:hover,
 .btn-link:focus {
   color: #2a6496;
   text-decoration: underline;
   background-color: transparent;
 }
-/* line 112, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/buttons.less */
 .btn-link[disabled]:hover,
 fieldset[disabled] .btn-link:hover,
 .btn-link[disabled]:focus,
@@ -2634,14 +2211,12 @@ fieldset[disabled] .btn-link:focus {
   color: #999999;
   text-decoration: none;
 }
-/* line 124, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/buttons.less */
 .btn-lg {
   padding: 10px 16px;
   font-size: 18px;
   line-height: 1.33;
   border-radius: 6px;
 }
-/* line 128, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/buttons.less */
 .btn-sm,
 .btn-xs {
   padding: 5px 10px;
@@ -2649,46 +2224,37 @@ fieldset[disabled] .btn-link:focus {
   line-height: 1.5;
   border-radius: 3px;
 }
-/* line 133, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/buttons.less */
 .btn-xs {
   padding: 1px 5px;
 }
-/* line 141, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/buttons.less */
 .btn-block {
   display: block;
   width: 100%;
   padding-left: 0;
   padding-right: 0;
 }
-/* line 149, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/buttons.less */
 .btn-block + .btn-block {
   margin-top: 5px;
 }
-/* line 157, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/buttons.less */
 input[type="submit"].btn-block,
 input[type="reset"].btn-block,
 input[type="button"].btn-block {
   width: 100%;
 }
-/* line 10, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/component-animations.less */
 .fade {
   opacity: 0;
   -webkit-transition: opacity 0.15s linear;
   transition: opacity 0.15s linear;
 }
-/* line 13, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/component-animations.less */
 .fade.in {
   opacity: 1;
 }
-/* line 18, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/component-animations.less */
 .collapse {
   display: none;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/component-animations.less */
 .collapse.in {
   display: block;
 }
-/* line 24, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/component-animations.less */
 .collapsing {
   position: relative;
   height: 0;
@@ -2701,7 +2267,6 @@ input[type="button"].btn-block {
   src: url('../fonts/glyphicons-halflings-regular.eot');
   src: url('../fonts/glyphicons-halflings-regular.eot?#iefix') format('embedded-opentype'), url('../fonts/glyphicons-halflings-regular.woff') format('woff'), url('../fonts/glyphicons-halflings-regular.ttf') format('truetype'), url('../fonts/glyphicons-halflings-regular.svg#glyphicons-halflingsregular') format('svg');
 }
-/* line 21, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon {
   position: relative;
   top: 1px;
@@ -2712,807 +2277,606 @@ input[type="button"].btn-block {
   line-height: 1;
   -webkit-font-smoothing: antialiased;
 }
-/* line 33, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-asterisk:before {
   content: "\2a";
 }
-/* line 34, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-plus:before {
   content: "\2b";
 }
-/* line 35, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-euro:before {
   content: "\20ac";
 }
-/* line 36, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-minus:before {
   content: "\2212";
 }
-/* line 37, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-cloud:before {
   content: "\2601";
 }
-/* line 38, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-envelope:before {
   content: "\2709";
 }
-/* line 39, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-pencil:before {
   content: "\270f";
 }
-/* line 40, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-glass:before {
   content: "\e001";
 }
-/* line 41, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-music:before {
   content: "\e002";
 }
-/* line 42, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-search:before {
   content: "\e003";
 }
-/* line 43, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-heart:before {
   content: "\e005";
 }
-/* line 44, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-star:before {
   content: "\e006";
 }
-/* line 45, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-star-empty:before {
   content: "\e007";
 }
-/* line 46, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-user:before {
   content: "\e008";
 }
-/* line 47, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-film:before {
   content: "\e009";
 }
-/* line 48, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-th-large:before {
   content: "\e010";
 }
-/* line 49, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-th:before {
   content: "\e011";
 }
-/* line 50, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-th-list:before {
   content: "\e012";
 }
-/* line 51, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-ok:before {
   content: "\e013";
 }
-/* line 52, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-remove:before {
   content: "\e014";
 }
-/* line 53, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-zoom-in:before {
   content: "\e015";
 }
-/* line 54, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-zoom-out:before {
   content: "\e016";
 }
-/* line 55, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-off:before {
   content: "\e017";
 }
-/* line 56, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-signal:before {
   content: "\e018";
 }
-/* line 57, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-cog:before {
   content: "\e019";
 }
-/* line 58, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-trash:before {
   content: "\e020";
 }
-/* line 59, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-home:before {
   content: "\e021";
 }
-/* line 60, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-file:before {
   content: "\e022";
 }
-/* line 61, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-time:before {
   content: "\e023";
 }
-/* line 62, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-road:before {
   content: "\e024";
 }
-/* line 63, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-download-alt:before {
   content: "\e025";
 }
-/* line 64, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-download:before {
   content: "\e026";
 }
-/* line 65, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-upload:before {
   content: "\e027";
 }
-/* line 66, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-inbox:before {
   content: "\e028";
 }
-/* line 67, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-play-circle:before {
   content: "\e029";
 }
-/* line 68, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-repeat:before {
   content: "\e030";
 }
-/* line 69, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-refresh:before {
   content: "\e031";
 }
-/* line 70, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-list-alt:before {
   content: "\e032";
 }
-/* line 71, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-flag:before {
   content: "\e034";
 }
-/* line 72, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-headphones:before {
   content: "\e035";
 }
-/* line 73, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-volume-off:before {
   content: "\e036";
 }
-/* line 74, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-volume-down:before {
   content: "\e037";
 }
-/* line 75, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-volume-up:before {
   content: "\e038";
 }
-/* line 76, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-qrcode:before {
   content: "\e039";
 }
-/* line 77, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-barcode:before {
   content: "\e040";
 }
-/* line 78, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-tag:before {
   content: "\e041";
 }
-/* line 79, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-tags:before {
   content: "\e042";
 }
-/* line 80, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-book:before {
   content: "\e043";
 }
-/* line 81, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-print:before {
   content: "\e045";
 }
-/* line 82, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-font:before {
   content: "\e047";
 }
-/* line 83, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-bold:before {
   content: "\e048";
 }
-/* line 84, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-italic:before {
   content: "\e049";
 }
-/* line 85, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-text-height:before {
   content: "\e050";
 }
-/* line 86, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-text-width:before {
   content: "\e051";
 }
-/* line 87, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-align-left:before {
   content: "\e052";
 }
-/* line 88, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-align-center:before {
   content: "\e053";
 }
-/* line 89, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-align-right:before {
   content: "\e054";
 }
-/* line 90, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-align-justify:before {
   content: "\e055";
 }
-/* line 91, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-list:before {
   content: "\e056";
 }
-/* line 92, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-indent-left:before {
   content: "\e057";
 }
-/* line 93, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-indent-right:before {
   content: "\e058";
 }
-/* line 94, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-facetime-video:before {
   content: "\e059";
 }
-/* line 95, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-picture:before {
   content: "\e060";
 }
-/* line 96, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-map-marker:before {
   content: "\e062";
 }
-/* line 97, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-adjust:before {
   content: "\e063";
 }
-/* line 98, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-tint:before {
   content: "\e064";
 }
-/* line 99, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-edit:before {
   content: "\e065";
 }
-/* line 100, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-share:before {
   content: "\e066";
 }
-/* line 101, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-check:before {
   content: "\e067";
 }
-/* line 102, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-move:before {
   content: "\e068";
 }
-/* line 103, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-step-backward:before {
   content: "\e069";
 }
-/* line 104, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-fast-backward:before {
   content: "\e070";
 }
-/* line 105, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-backward:before {
   content: "\e071";
 }
-/* line 106, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-play:before {
   content: "\e072";
 }
-/* line 107, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-pause:before {
   content: "\e073";
 }
-/* line 108, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-stop:before {
   content: "\e074";
 }
-/* line 109, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-forward:before {
   content: "\e075";
 }
-/* line 110, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-fast-forward:before {
   content: "\e076";
 }
-/* line 111, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-step-forward:before {
   content: "\e077";
 }
-/* line 112, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-eject:before {
   content: "\e078";
 }
-/* line 113, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-chevron-left:before {
   content: "\e079";
 }
-/* line 114, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-chevron-right:before {
   content: "\e080";
 }
-/* line 115, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-plus-sign:before {
   content: "\e081";
 }
-/* line 116, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-minus-sign:before {
   content: "\e082";
 }
-/* line 117, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-remove-sign:before {
   content: "\e083";
 }
-/* line 118, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-ok-sign:before {
   content: "\e084";
 }
-/* line 119, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-question-sign:before {
   content: "\e085";
 }
-/* line 120, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-info-sign:before {
   content: "\e086";
 }
-/* line 121, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-screenshot:before {
   content: "\e087";
 }
-/* line 122, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-remove-circle:before {
   content: "\e088";
 }
-/* line 123, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-ok-circle:before {
   content: "\e089";
 }
-/* line 124, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-ban-circle:before {
   content: "\e090";
 }
-/* line 125, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-arrow-left:before {
   content: "\e091";
 }
-/* line 126, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-arrow-right:before {
   content: "\e092";
 }
-/* line 127, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-arrow-up:before {
   content: "\e093";
 }
-/* line 128, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-arrow-down:before {
   content: "\e094";
 }
-/* line 129, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-share-alt:before {
   content: "\e095";
 }
-/* line 130, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-resize-full:before {
   content: "\e096";
 }
-/* line 131, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-resize-small:before {
   content: "\e097";
 }
-/* line 132, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-exclamation-sign:before {
   content: "\e101";
 }
-/* line 133, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-gift:before {
   content: "\e102";
 }
-/* line 134, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-leaf:before {
   content: "\e103";
 }
-/* line 135, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-eye-open:before {
   content: "\e105";
 }
-/* line 136, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-eye-close:before {
   content: "\e106";
 }
-/* line 137, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-warning-sign:before {
   content: "\e107";
 }
-/* line 138, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-plane:before {
   content: "\e108";
 }
-/* line 139, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-random:before {
   content: "\e110";
 }
-/* line 140, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-comment:before {
   content: "\e111";
 }
-/* line 141, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-magnet:before {
   content: "\e112";
 }
-/* line 142, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-chevron-up:before {
   content: "\e113";
 }
-/* line 143, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-chevron-down:before {
   content: "\e114";
 }
-/* line 144, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-retweet:before {
   content: "\e115";
 }
-/* line 145, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-shopping-cart:before {
   content: "\e116";
 }
-/* line 146, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-folder-close:before {
   content: "\e117";
 }
-/* line 147, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-folder-open:before {
   content: "\e118";
 }
-/* line 148, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-resize-vertical:before {
   content: "\e119";
 }
-/* line 149, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-resize-horizontal:before {
   content: "\e120";
 }
-/* line 150, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-hdd:before {
   content: "\e121";
 }
-/* line 151, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-bullhorn:before {
   content: "\e122";
 }
-/* line 152, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-certificate:before {
   content: "\e124";
 }
-/* line 153, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-thumbs-up:before {
   content: "\e125";
 }
-/* line 154, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-thumbs-down:before {
   content: "\e126";
 }
-/* line 155, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-hand-right:before {
   content: "\e127";
 }
-/* line 156, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-hand-left:before {
   content: "\e128";
 }
-/* line 157, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-hand-up:before {
   content: "\e129";
 }
-/* line 158, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-hand-down:before {
   content: "\e130";
 }
-/* line 159, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-circle-arrow-right:before {
   content: "\e131";
 }
-/* line 160, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-circle-arrow-left:before {
   content: "\e132";
 }
-/* line 161, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-circle-arrow-up:before {
   content: "\e133";
 }
-/* line 162, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-circle-arrow-down:before {
   content: "\e134";
 }
-/* line 163, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-globe:before {
   content: "\e135";
 }
-/* line 164, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-tasks:before {
   content: "\e137";
 }
-/* line 165, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-filter:before {
   content: "\e138";
 }
-/* line 166, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-fullscreen:before {
   content: "\e140";
 }
-/* line 167, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-dashboard:before {
   content: "\e141";
 }
-/* line 168, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-heart-empty:before {
   content: "\e143";
 }
-/* line 169, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-link:before {
   content: "\e144";
 }
-/* line 170, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-phone:before {
   content: "\e145";
 }
-/* line 171, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-usd:before {
   content: "\e148";
 }
-/* line 172, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-gbp:before {
   content: "\e149";
 }
-/* line 173, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-sort:before {
   content: "\e150";
 }
-/* line 174, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-sort-by-alphabet:before {
   content: "\e151";
 }
-/* line 175, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-sort-by-alphabet-alt:before {
   content: "\e152";
 }
-/* line 176, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-sort-by-order:before {
   content: "\e153";
 }
-/* line 177, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-sort-by-order-alt:before {
   content: "\e154";
 }
-/* line 178, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-sort-by-attributes:before {
   content: "\e155";
 }
-/* line 179, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-sort-by-attributes-alt:before {
   content: "\e156";
 }
-/* line 180, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-unchecked:before {
   content: "\e157";
 }
-/* line 181, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-expand:before {
   content: "\e158";
 }
-/* line 182, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-collapse-down:before {
   content: "\e159";
 }
-/* line 183, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-collapse-up:before {
   content: "\e160";
 }
-/* line 184, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-log-in:before {
   content: "\e161";
 }
-/* line 185, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-flash:before {
   content: "\e162";
 }
-/* line 186, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-log-out:before {
   content: "\e163";
 }
-/* line 187, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-new-window:before {
   content: "\e164";
 }
-/* line 188, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-record:before {
   content: "\e165";
 }
-/* line 189, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-save:before {
   content: "\e166";
 }
-/* line 190, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-open:before {
   content: "\e167";
 }
-/* line 191, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-saved:before {
   content: "\e168";
 }
-/* line 192, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-import:before {
   content: "\e169";
 }
-/* line 193, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-export:before {
   content: "\e170";
 }
-/* line 194, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-send:before {
   content: "\e171";
 }
-/* line 195, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-floppy-disk:before {
   content: "\e172";
 }
-/* line 196, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-floppy-saved:before {
   content: "\e173";
 }
-/* line 197, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-floppy-remove:before {
   content: "\e174";
 }
-/* line 198, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-floppy-save:before {
   content: "\e175";
 }
-/* line 199, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-floppy-open:before {
   content: "\e176";
 }
-/* line 200, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-credit-card:before {
   content: "\e177";
 }
-/* line 201, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-transfer:before {
   content: "\e178";
 }
-/* line 202, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-cutlery:before {
   content: "\e179";
 }
-/* line 203, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-header:before {
   content: "\e180";
 }
-/* line 204, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-compressed:before {
   content: "\e181";
 }
-/* line 205, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-earphone:before {
   content: "\e182";
 }
-/* line 206, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-phone-alt:before {
   content: "\e183";
 }
-/* line 207, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-tower:before {
   content: "\e184";
 }
-/* line 208, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-stats:before {
   content: "\e185";
 }
-/* line 209, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-sd-video:before {
   content: "\e186";
 }
-/* line 210, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-hd-video:before {
   content: "\e187";
 }
-/* line 211, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-subtitles:before {
   content: "\e188";
 }
-/* line 212, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-sound-stereo:before {
   content: "\e189";
 }
-/* line 213, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-sound-dolby:before {
   content: "\e190";
 }
-/* line 214, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-sound-5-1:before {
   content: "\e191";
 }
-/* line 215, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-sound-6-1:before {
   content: "\e192";
 }
-/* line 216, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-sound-7-1:before {
   content: "\e193";
 }
-/* line 217, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-copyright-mark:before {
   content: "\e194";
 }
-/* line 218, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-registration-mark:before {
   content: "\e195";
 }
-/* line 219, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-cloud-download:before {
   content: "\e197";
 }
-/* line 220, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-cloud-upload:before {
   content: "\e198";
 }
-/* line 221, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-tree-conifer:before {
   content: "\e199";
 }
-/* line 222, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-tree-deciduous:before {
   content: "\e200";
 }
-/* line 223, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-briefcase:before {
   content: "\1f4bc";
 }
-/* line 224, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-calendar:before {
   content: "\1f4c5";
 }
-/* line 225, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-pushpin:before {
   content: "\1f4cc";
 }
-/* line 226, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-paperclip:before {
   content: "\1f4ce";
 }
-/* line 227, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-camera:before {
   content: "\1f4f7";
 }
-/* line 228, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-lock:before {
   content: "\1f512";
 }
-/* line 229, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-bell:before {
   content: "\1f514";
 }
-/* line 230, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-bookmark:before {
   content: "\1f516";
 }
-/* line 231, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-fire:before {
   content: "\1f525";
 }
-/* line 232, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/glyphicons.less */
 .glyphicon-wrench:before {
   content: "\1f527";
 }
-/* line 7, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/dropdowns.less */
 .caret {
   display: inline-block;
   width: 0;
@@ -3525,15 +2889,12 @@ input[type="button"].btn-block {
   border-bottom: 0 dotted;
   content: "";
 }
-/* line 23, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/dropdowns.less */
 .dropdown {
   position: relative;
 }
-/* line 28, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/dropdowns.less */
 .dropdown-toggle:focus {
   outline: 0;
 }
-/* line 33, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/dropdowns.less */
 .dropdown-menu {
   position: absolute;
   top: 100%;
@@ -3554,19 +2915,16 @@ input[type="button"].btn-block {
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
   background-clip: padding-box;
 }
-/* line 53, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/dropdowns.less */
 .dropdown-menu.pull-right {
   right: 0;
   left: auto;
 }
-/* line 59, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/dropdowns.less */
 .dropdown-menu .divider {
   height: 1px;
   margin: 9px 0;
   overflow: hidden;
   background-color: #e5e5e5;
 }
-/* line 64, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/dropdowns.less */
 .dropdown-menu > li > a {
   display: block;
   padding: 3px 20px;
@@ -3576,14 +2934,12 @@ input[type="button"].btn-block {
   color: #333333;
   white-space: nowrap;
 }
-/* line 77, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/dropdowns.less */
 .dropdown-menu > li > a:hover,
 .dropdown-menu > li > a:focus {
   text-decoration: none;
   color: #ffffff;
   background-color: #428bca;
 }
-/* line 87, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/dropdowns.less */
 .dropdown-menu > .active > a,
 .dropdown-menu > .active > a:hover,
 .dropdown-menu > .active > a:focus {
@@ -3592,13 +2948,11 @@ input[type="button"].btn-block {
   outline: 0;
   background-color: #428bca;
 }
-/* line 102, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/dropdowns.less */
 .dropdown-menu > .disabled > a,
 .dropdown-menu > .disabled > a:hover,
 .dropdown-menu > .disabled > a:focus {
   color: #999999;
 }
-/* line 110, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/dropdowns.less */
 .dropdown-menu > .disabled > a:hover,
 .dropdown-menu > .disabled > a:focus {
   text-decoration: none;
@@ -3607,15 +2961,12 @@ input[type="button"].btn-block {
   filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
   cursor: not-allowed;
 }
-/* line 123, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/dropdowns.less */
 .open > .dropdown-menu {
   display: block;
 }
-/* line 128, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/dropdowns.less */
 .open > a {
   outline: 0;
 }
-/* line 134, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/dropdowns.less */
 .dropdown-header {
   display: block;
   padding: 3px 20px;
@@ -3623,7 +2974,6 @@ input[type="button"].btn-block {
   line-height: 1.428571429;
   color: #999999;
 }
-/* line 143, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/dropdowns.less */
 .dropdown-backdrop {
   position: fixed;
   left: 0;
@@ -3632,19 +2982,16 @@ input[type="button"].btn-block {
   top: 0;
   z-index: 990;
 }
-/* line 153, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/dropdowns.less */
 .pull-right > .dropdown-menu {
   right: 0;
   left: auto;
 }
-/* line 166, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/dropdowns.less */
 .dropup .caret,
 .navbar-fixed-bottom .dropdown .caret {
   border-top: 0 dotted;
   border-bottom: 4px solid #000000;
   content: "";
 }
-/* line 174, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/dropdowns.less */
 .dropup .dropdown-menu,
 .navbar-fixed-bottom .dropdown .dropdown-menu {
   top: auto;
@@ -3652,17 +2999,14 @@ input[type="button"].btn-block {
   margin-bottom: 1px;
 }
 @media (min-width: 768px) {
-  /* line 188, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/dropdowns.less */
   .navbar-right .dropdown-menu {
     right: 0;
     left: auto;
   }
 }
-/* line 10, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-default .caret {
   border-top-color: #333333;
 }
-/* line 13, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-primary .caret,
 .btn-success .caret,
 .btn-warning .caret,
@@ -3670,11 +3014,9 @@ input[type="button"].btn-block {
 .btn-info .caret {
   border-top-color: #fff;
 }
-/* line 22, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .dropup .btn-default .caret {
   border-bottom-color: #333333;
 }
-/* line 30, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .dropup .btn-primary .caret,
 .dropup .btn-success .caret,
 .dropup .btn-warning .caret,
@@ -3682,20 +3024,17 @@ input[type="button"].btn-block {
 .dropup .btn-info .caret {
   border-bottom-color: #fff;
 }
-/* line 37, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-group,
 .btn-group-vertical {
   position: relative;
   display: inline-block;
   vertical-align: middle;
 }
-/* line 42, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-group > .btn,
 .btn-group-vertical > .btn {
   position: relative;
   float: left;
 }
-/* line 46, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-group > .btn:hover,
 .btn-group-vertical > .btn:hover,
 .btn-group > .btn:focus,
@@ -3706,19 +3045,16 @@ input[type="button"].btn-block {
 .btn-group-vertical > .btn.active {
   z-index: 2;
 }
-/* line 52, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-group > .btn:focus,
 .btn-group-vertical > .btn:focus {
   outline: none;
 }
-/* line 61, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-group .btn + .btn,
 .btn-group .btn + .btn-group,
 .btn-group .btn-group + .btn,
 .btn-group .btn-group + .btn-group {
   margin-left: -1px;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .btn-toolbar:before,
 .btn-toolbar:after {
   content: " ";
@@ -3728,11 +3064,9 @@ input[type="button"].btn-block {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .btn-toolbar:after {
   clear: both;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .btn-toolbar:before,
 .btn-toolbar:after {
   content: " ";
@@ -3742,65 +3076,52 @@ input[type="button"].btn-block {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .btn-toolbar:after {
   clear: both;
 }
-/* line 73, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-toolbar .btn-group {
   float: left;
 }
-/* line 79, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-toolbar > .btn + .btn,
 .btn-toolbar > .btn-group + .btn,
 .btn-toolbar > .btn + .btn-group,
 .btn-toolbar > .btn-group + .btn-group {
   margin-left: 5px;
 }
-/* line 86, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-group > .btn:not(:first-child):not(:last-child):not(.dropdown-toggle) {
   border-radius: 0;
 }
-/* line 91, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-group > .btn:first-child {
   margin-left: 0;
 }
-/* line 93, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-group > .btn:first-child:not(:last-child):not(.dropdown-toggle) {
   border-bottom-right-radius: 0;
   border-top-right-radius: 0;
 }
-/* line 98, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-group > .btn:last-child:not(:first-child),
 .btn-group > .dropdown-toggle:not(:first-child) {
   border-bottom-left-radius: 0;
   border-top-left-radius: 0;
 }
-/* line 104, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-group > .btn-group {
   float: left;
 }
-/* line 107, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-group > .btn-group:not(:first-child):not(:last-child) > .btn {
   border-radius: 0;
 }
-/* line 111, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-group > .btn-group:first-child > .btn:last-child,
 .btn-group > .btn-group:first-child > .dropdown-toggle {
   border-bottom-right-radius: 0;
   border-top-right-radius: 0;
 }
-/* line 116, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-group > .btn-group:last-child > .btn:first-child {
   border-bottom-left-radius: 0;
   border-top-left-radius: 0;
 }
-/* line 121, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-group .dropdown-toggle:active,
 .btn-group.open .dropdown-toggle {
   outline: 0;
 }
-/* line 131, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-group-xs > .btn {
   padding: 5px 10px;
   font-size: 12px;
@@ -3808,49 +3129,40 @@ input[type="button"].btn-block {
   border-radius: 3px;
   padding: 1px 5px;
 }
-/* line 132, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-group-sm > .btn {
   padding: 5px 10px;
   font-size: 12px;
   line-height: 1.5;
   border-radius: 3px;
 }
-/* line 133, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-group-lg > .btn {
   padding: 10px 16px;
   font-size: 18px;
   line-height: 1.33;
   border-radius: 6px;
 }
-/* line 140, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-group > .btn + .dropdown-toggle {
   padding-left: 8px;
   padding-right: 8px;
 }
-/* line 144, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-group > .btn-lg + .dropdown-toggle {
   padding-left: 12px;
   padding-right: 12px;
 }
-/* line 151, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-group.open .dropdown-toggle {
   -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
 }
-/* line 157, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn .caret {
   margin-left: 0;
 }
-/* line 161, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-lg .caret {
   border-width: 5px 5px 0;
   border-bottom-width: 0;
 }
-/* line 166, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .dropup .btn-lg .caret {
   border-width: 0 5px 5px;
 }
-/* line 175, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-group-vertical > .btn,
 .btn-group-vertical > .btn-group {
   display: block;
@@ -3858,7 +3170,6 @@ input[type="button"].btn-block {
   width: 100%;
   max-width: 100%;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .btn-group-vertical > .btn-group:before,
 .btn-group-vertical > .btn-group:after {
   content: " ";
@@ -3868,11 +3179,9 @@ input[type="button"].btn-block {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .btn-group-vertical > .btn-group:after {
   clear: both;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .btn-group-vertical > .btn-group:before,
 .btn-group-vertical > .btn-group:after {
   content: " ";
@@ -3882,15 +3191,12 @@ input[type="button"].btn-block {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .btn-group-vertical > .btn-group:after {
   clear: both;
 }
-/* line 186, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-group-vertical > .btn-group > .btn {
   float: none;
 }
-/* line 191, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-group-vertical > .btn + .btn,
 .btn-group-vertical > .btn + .btn-group,
 .btn-group-vertical > .btn-group + .btn,
@@ -3898,73 +3204,60 @@ input[type="button"].btn-block {
   margin-top: -1px;
   margin-left: 0;
 }
-/* line 201, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-group-vertical > .btn:not(:first-child):not(:last-child) {
   border-radius: 0;
 }
-/* line 204, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-group-vertical > .btn:first-child:not(:last-child) {
   border-top-right-radius: 4px;
   border-bottom-right-radius: 0;
   border-bottom-left-radius: 0;
 }
-/* line 208, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-group-vertical > .btn:last-child:not(:first-child) {
   border-bottom-left-radius: 4px;
   border-top-right-radius: 0;
   border-top-left-radius: 0;
 }
-/* line 213, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-group-vertical > .btn-group:not(:first-child):not(:last-child) > .btn {
   border-radius: 0;
 }
-/* line 217, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-group-vertical > .btn-group:first-child > .btn:last-child,
 .btn-group-vertical > .btn-group:first-child > .dropdown-toggle {
   border-bottom-right-radius: 0;
   border-bottom-left-radius: 0;
 }
-/* line 222, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-group-vertical > .btn-group:last-child > .btn:first-child {
   border-top-right-radius: 0;
   border-top-left-radius: 0;
 }
-/* line 231, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-group-justified {
   display: table;
   width: 100%;
   table-layout: fixed;
   border-collapse: separate;
 }
-/* line 236, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 .btn-group-justified .btn {
   float: none;
   display: table-cell;
   width: 1%;
 }
-/* line 245, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/button-groups.less */
 [data-toggle="buttons"] > .btn > input[type="radio"],
 [data-toggle="buttons"] > .btn > input[type="checkbox"] {
   display: none;
 }
-/* line 7, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/input-groups.less */
 .input-group {
   position: relative;
   display: table;
   border-collapse: separate;
 }
-/* line 13, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/input-groups.less */
 .input-group.col {
   float: none;
   padding-left: 0;
   padding-right: 0;
 }
-/* line 19, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/input-groups.less */
 .input-group .form-control {
   width: 100%;
   margin-bottom: 0;
 }
-/* line 30, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/input-groups.less */
 .input-group-lg > .form-control,
 .input-group-lg > .input-group-addon,
 .input-group-lg > .input-group-btn > .btn {
@@ -3974,20 +3267,17 @@ input[type="button"].btn-block {
   line-height: 1.33;
   border-radius: 6px;
 }
-/* line 715, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 select.input-group-lg > .form-control,
 select.input-group-lg > .input-group-addon,
 select.input-group-lg > .input-group-btn > .btn {
   height: 45px;
   line-height: 45px;
 }
-/* line 720, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 textarea.input-group-lg > .form-control,
 textarea.input-group-lg > .input-group-addon,
 textarea.input-group-lg > .input-group-btn > .btn {
   height: auto;
 }
-/* line 33, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/input-groups.less */
 .input-group-sm > .form-control,
 .input-group-sm > .input-group-addon,
 .input-group-sm > .input-group-btn > .btn {
@@ -3997,39 +3287,33 @@ textarea.input-group-lg > .input-group-btn > .btn {
   line-height: 1.5;
   border-radius: 3px;
 }
-/* line 715, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 select.input-group-sm > .form-control,
 select.input-group-sm > .input-group-addon,
 select.input-group-sm > .input-group-btn > .btn {
   height: 30px;
   line-height: 30px;
 }
-/* line 720, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 textarea.input-group-sm > .form-control,
 textarea.input-group-sm > .input-group-addon,
 textarea.input-group-sm > .input-group-btn > .btn {
   height: auto;
 }
-/* line 40, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/input-groups.less */
 .input-group-addon,
 .input-group-btn,
 .input-group .form-control {
   display: table-cell;
 }
-/* line 45, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/input-groups.less */
 .input-group-addon:not(:first-child):not(:last-child),
 .input-group-btn:not(:first-child):not(:last-child),
 .input-group .form-control:not(:first-child):not(:last-child) {
   border-radius: 0;
 }
-/* line 50, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/input-groups.less */
 .input-group-addon,
 .input-group-btn {
   width: 1%;
   white-space: nowrap;
   vertical-align: middle;
 }
-/* line 59, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/input-groups.less */
 .input-group-addon {
   padding: 6px 12px;
   font-size: 14px;
@@ -4040,24 +3324,20 @@ textarea.input-group-sm > .input-group-btn > .btn {
   border: 1px solid #cccccc;
   border-radius: 4px;
 }
-/* line 70, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/input-groups.less */
 .input-group-addon.input-sm {
   padding: 5px 10px;
   font-size: 12px;
   border-radius: 3px;
 }
-/* line 75, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/input-groups.less */
 .input-group-addon.input-lg {
   padding: 10px 16px;
   font-size: 18px;
   border-radius: 6px;
 }
-/* line 82, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/input-groups.less */
 .input-group-addon input[type="radio"],
 .input-group-addon input[type="checkbox"] {
   margin-top: 0;
 }
-/* line 89, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/input-groups.less */
 .input-group .form-control:first-child,
 .input-group-addon:first-child,
 .input-group-btn:first-child > .btn,
@@ -4066,11 +3346,9 @@ textarea.input-group-sm > .input-group-btn > .btn {
   border-bottom-right-radius: 0;
   border-top-right-radius: 0;
 }
-/* line 96, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/input-groups.less */
 .input-group-addon:first-child {
   border-right: 0;
 }
-/* line 99, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/input-groups.less */
 .input-group .form-control:last-child,
 .input-group-addon:last-child,
 .input-group-btn:last-child > .btn,
@@ -4079,35 +3357,28 @@ textarea.input-group-sm > .input-group-btn > .btn {
   border-bottom-left-radius: 0;
   border-top-left-radius: 0;
 }
-/* line 106, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/input-groups.less */
 .input-group-addon:last-child {
   border-left: 0;
 }
-/* line 112, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/input-groups.less */
 .input-group-btn {
   position: relative;
   white-space: nowrap;
 }
-/* line 116, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/input-groups.less */
 .input-group-btn > .btn {
   position: relative;
 }
-/* line 119, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/input-groups.less */
 .input-group-btn > .btn + .btn {
   margin-left: -4px;
 }
-/* line 123, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/input-groups.less */
 .input-group-btn > .btn:hover,
 .input-group-btn > .btn:active {
   z-index: 2;
 }
-/* line 9, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .nav {
   margin-bottom: 0;
   padding-left: 0;
   list-style: none;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .nav:before,
 .nav:after {
   content: " ";
@@ -4117,11 +3388,9 @@ textarea.input-group-sm > .input-group-btn > .btn {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .nav:after {
   clear: both;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .nav:before,
 .nav:after {
   content: " ";
@@ -4131,32 +3400,26 @@ textarea.input-group-sm > .input-group-btn > .btn {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .nav:after {
   clear: both;
 }
-/* line 15, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .nav > li {
   position: relative;
   display: block;
 }
-/* line 19, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .nav > li > a {
   position: relative;
   display: block;
   padding: 10px 15px;
 }
-/* line 23, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .nav > li > a:hover,
 .nav > li > a:focus {
   text-decoration: none;
   background-color: #eeeeee;
 }
-/* line 31, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .nav > li.disabled > a {
   color: #999999;
 }
-/* line 34, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .nav > li.disabled > a:hover,
 .nav > li.disabled > a:focus {
   color: #999999;
@@ -4164,45 +3427,37 @@ textarea.input-group-sm > .input-group-btn > .btn {
   background-color: transparent;
   cursor: not-allowed;
 }
-/* line 46, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .nav .open > a,
 .nav .open > a:hover,
 .nav .open > a:focus {
   background-color: #eeeeee;
   border-color: #428bca;
 }
-/* line 55, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .nav .nav-divider {
   height: 1px;
   margin: 9px 0;
   overflow: hidden;
   background-color: #e5e5e5;
 }
-/* line 61, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .nav > li > a > img {
   max-width: none;
 }
-/* line 71, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .nav-tabs {
   border-bottom: 1px solid #dddddd;
 }
-/* line 73, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .nav-tabs > li {
   float: left;
   margin-bottom: -1px;
 }
-/* line 79, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .nav-tabs > li > a {
   margin-right: 2px;
   line-height: 1.428571429;
   border: 1px solid transparent;
   border-radius: 4px 4px 0 0;
 }
-/* line 84, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .nav-tabs > li > a:hover {
   border-color: #eeeeee #eeeeee #dddddd;
 }
-/* line 91, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .nav-tabs > li.active > a,
 .nav-tabs > li.active > a:hover,
 .nav-tabs > li.active > a:focus {
@@ -4212,96 +3467,76 @@ textarea.input-group-sm > .input-group-btn > .btn {
   border-bottom-color: transparent;
   cursor: default;
 }
-/* line 103, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .nav-tabs.nav-justified {
   width: 100%;
   border-bottom: 0;
 }
-/* line 158, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .nav-tabs.nav-justified > li {
   float: none;
 }
-/* line 160, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .nav-tabs.nav-justified > li > a {
   text-align: center;
 }
 @media (min-width: 768px) {
-  /* line 166, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
   .nav-tabs.nav-justified > li {
     display: table-cell;
     width: 1%;
   }
 }
-/* line 176, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .nav-tabs.nav-justified > li > a {
   border-bottom: 1px solid #dddddd;
   margin-right: 0;
 }
-/* line 182, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .nav-tabs.nav-justified > .active > a {
   border-bottom-color: #ffffff;
 }
-/* line 113, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .nav-pills > li {
   float: left;
 }
-/* line 117, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .nav-pills > li > a {
   border-radius: 5px;
 }
-/* line 120, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .nav-pills > li + li {
   margin-left: 2px;
 }
-/* line 126, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .nav-pills > li.active > a,
 .nav-pills > li.active > a:hover,
 .nav-pills > li.active > a:focus {
   color: #ffffff;
   background-color: #428bca;
 }
-/* line 139, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .nav-stacked > li {
   float: none;
 }
-/* line 141, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .nav-stacked > li + li {
   margin-top: 2px;
   margin-left: 0;
 }
-/* line 155, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .nav-justified {
   width: 100%;
 }
-/* line 158, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .nav-justified > li {
   float: none;
 }
-/* line 160, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .nav-justified > li > a {
   text-align: center;
 }
 @media (min-width: 768px) {
-  /* line 166, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
   .nav-justified > li {
     display: table-cell;
     width: 1%;
   }
 }
-/* line 174, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .nav-tabs-justified {
   border-bottom: 0;
 }
-/* line 176, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .nav-tabs-justified > li > a {
   border-bottom: 1px solid #dddddd;
   margin-right: 0;
 }
-/* line 182, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .nav-tabs-justified > .active > a {
   border-bottom-color: #ffffff;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .tabbable:before,
 .tabbable:after {
   content: " ";
@@ -4311,11 +3546,9 @@ textarea.input-group-sm > .input-group-btn > .btn {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .tabbable:after {
   clear: both;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .tabbable:before,
 .tabbable:after {
   content: " ";
@@ -4325,37 +3558,30 @@ textarea.input-group-sm > .input-group-btn > .btn {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .tabbable:after {
   clear: both;
 }
-/* line 197, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .tab-content > .tab-pane,
 .pill-content > .pill-pane {
   display: none;
 }
-/* line 203, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .tab-content > .active,
 .pill-content > .active {
   display: block;
 }
-/* line 214, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .nav .caret {
   border-top-color: #428bca;
   border-bottom-color: #428bca;
 }
-/* line 218, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .nav a:hover .caret {
   border-top-color: #2a6496;
   border-bottom-color: #2a6496;
 }
-/* line 224, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navs.less */
 .nav-tabs .dropdown-menu {
   margin-top: -1px;
   border-top-right-radius: 0;
   border-top-left-radius: 0;
 }
-/* line 11, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar {
   position: relative;
   z-index: 1000;
@@ -4363,7 +3589,6 @@ textarea.input-group-sm > .input-group-btn > .btn {
   margin-bottom: 20px;
   border: 1px solid transparent;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .navbar:before,
 .navbar:after {
   content: " ";
@@ -4373,11 +3598,9 @@ textarea.input-group-sm > .input-group-btn > .btn {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .navbar:after {
   clear: both;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .navbar:before,
 .navbar:after {
   content: " ";
@@ -4387,17 +3610,14 @@ textarea.input-group-sm > .input-group-btn > .btn {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .navbar:after {
   clear: both;
 }
 @media (min-width: 768px) {
-  /* line 21, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .navbar {
     border-radius: 4px;
   }
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .navbar-header:before,
 .navbar-header:after {
   content: " ";
@@ -4407,11 +3627,9 @@ textarea.input-group-sm > .input-group-btn > .btn {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .navbar-header:after {
   clear: both;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .navbar-header:before,
 .navbar-header:after {
   content: " ";
@@ -4421,17 +3639,14 @@ textarea.input-group-sm > .input-group-btn > .btn {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .navbar-header:after {
   clear: both;
 }
 @media (min-width: 768px) {
-  /* line 35, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .navbar-header {
     float: left;
   }
 }
-/* line 51, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-collapse {
   max-height: 340px;
   overflow-x: visible;
@@ -4441,7 +3656,6 @@ textarea.input-group-sm > .input-group-btn > .btn {
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
   -webkit-overflow-scrolling: touch;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .navbar-collapse:before,
 .navbar-collapse:after {
   content: " ";
@@ -4451,11 +3665,9 @@ textarea.input-group-sm > .input-group-btn > .btn {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .navbar-collapse:after {
   clear: both;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .navbar-collapse:before,
 .navbar-collapse:after {
   content: " ";
@@ -4465,46 +3677,37 @@ textarea.input-group-sm > .input-group-btn > .btn {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .navbar-collapse:after {
   clear: both;
 }
-/* line 61, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-collapse.in {
   overflow-y: auto;
 }
 @media (min-width: 768px) {
-  /* line 65, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .navbar-collapse {
     width: auto;
     border-top: 0;
     box-shadow: none;
   }
-  /* line 70, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .navbar-collapse.collapse {
     display: block !important;
     height: auto !important;
     padding-bottom: 0;
     overflow: visible !important;
   }
-  /* line 77, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .navbar-collapse.in {
     overflow-y: visible;
   }
-  /* line 82, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .navbar-collapse .navbar-nav.navbar-left:first-child {
     margin-left: -15px;
   }
-  /* line 85, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .navbar-collapse .navbar-nav.navbar-right:last-child {
     margin-right: -15px;
   }
-  /* line 88, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .navbar-collapse .navbar-text:last-child {
     margin-right: 0;
   }
 }
-/* line 99, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .container > .navbar-header,
 .container > .navbar-collapse,
 .wrap > .navbar-header,
@@ -4513,7 +3716,6 @@ textarea.input-group-sm > .input-group-btn > .btn {
   margin-left: -15px;
 }
 @media (min-width: 768px) {
-  /* line 104, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .container > .navbar-header,
   .container > .navbar-collapse,
   .wrap > .navbar-header,
@@ -4522,17 +3724,14 @@ textarea.input-group-sm > .input-group-btn > .btn {
     margin-left: 0;
   }
 }
-/* line 118, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-static-top {
   border-width: 0 0 1px;
 }
 @media (min-width: 768px) {
-  /* line 120, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .navbar-static-top {
     border-radius: 0;
   }
 }
-/* line 126, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-fixed-top,
 .navbar-fixed-bottom {
   position: fixed;
@@ -4541,42 +3740,35 @@ textarea.input-group-sm > .input-group-btn > .btn {
   border-width: 0 0 1px;
 }
 @media (min-width: 768px) {
-  /* line 134, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .navbar-fixed-top,
   .navbar-fixed-bottom {
     border-radius: 0;
   }
 }
-/* line 138, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-fixed-top {
   z-index: 1030;
   top: 0;
 }
-/* line 142, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-fixed-bottom {
   bottom: 0;
   margin-bottom: 0;
 }
-/* line 150, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-brand {
   float: left;
   padding: 13px 15px;
   font-size: 18px;
   line-height: 20px;
 }
-/* line 155, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-brand:hover,
 .navbar-brand:focus {
   text-decoration: none;
 }
 @media (min-width: 768px) {
-  /* line 161, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .navbar > .container .navbar-brand,
   .navbar > .wrap .navbar-brand {
     margin-left: -15px;
   }
 }
-/* line 173, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-toggle {
   position: relative;
   float: right;
@@ -4588,35 +3780,29 @@ textarea.input-group-sm > .input-group-btn > .btn {
   border: 1px solid transparent;
   border-radius: 4px;
 }
-/* line 184, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-toggle .icon-bar {
   display: block;
   width: 22px;
   height: 2px;
   border-radius: 1px;
 }
-/* line 190, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-toggle .icon-bar + .icon-bar {
   margin-top: 4px;
 }
 @media (min-width: 768px) {
-  /* line 194, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .navbar-toggle {
     display: none;
   }
 }
-/* line 205, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-nav {
   margin: 6.5px -15px;
 }
-/* line 208, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-nav > li > a {
   padding-top: 10px;
   padding-bottom: 10px;
   line-height: 20px;
 }
 @media (max-width: 767px) {
-  /* line 216, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .navbar-nav .open .dropdown-menu {
     position: static;
     float: none;
@@ -4626,50 +3812,41 @@ textarea.input-group-sm > .input-group-btn > .btn {
     border: 0;
     box-shadow: none;
   }
-  /* line 224, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .navbar-nav .open .dropdown-menu > li > a,
   .navbar-nav .open .dropdown-menu .dropdown-header {
     padding: 5px 15px 5px 25px;
   }
-  /* line 228, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .navbar-nav .open .dropdown-menu > li > a {
     line-height: 20px;
   }
-  /* line 230, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .navbar-nav .open .dropdown-menu > li > a:hover,
   .navbar-nav .open .dropdown-menu > li > a:focus {
     background-image: none;
   }
 }
 @media (min-width: 768px) {
-  /* line 239, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .navbar-nav {
     float: left;
     margin: 0;
   }
-  /* line 243, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .navbar-nav > li {
     float: left;
   }
-  /* line 245, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .navbar-nav > li > a {
     padding-top: 13px;
     padding-bottom: 13px;
   }
 }
 @media (min-width: 768px) {
-  /* line 262, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .navbar-left {
     float: left !important;
     float: left;
   }
-  /* line 263, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .navbar-right {
     float: right !important;
     float: right;
   }
 }
-/* line 272, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-form {
   margin-left: -15px;
   margin-right: -15px;
@@ -4682,17 +3859,14 @@ textarea.input-group-sm > .input-group-btn > .btn {
   margin-bottom: 6px;
 }
 @media (min-width: 768px) {
-  /* line 294, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
   .navbar-form .form-group {
     display: inline-block;
     margin-bottom: 0;
     vertical-align: middle;
   }
-  /* line 301, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
   .navbar-form .form-control {
     display: inline-block;
   }
-  /* line 308, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
   .navbar-form .radio,
   .navbar-form .checkbox {
     display: inline-block;
@@ -4700,7 +3874,6 @@ textarea.input-group-sm > .input-group-btn > .btn {
     margin-bottom: 0;
     padding-left: 0;
   }
-  /* line 315, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
   .navbar-form .radio input[type="radio"],
   .navbar-form .checkbox input[type="checkbox"] {
     float: none;
@@ -4708,13 +3881,11 @@ textarea.input-group-sm > .input-group-btn > .btn {
   }
 }
 @media (max-width: 767px) {
-  /* line 285, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .navbar-form .form-group {
     margin-bottom: 5px;
   }
 }
 @media (min-width: 768px) {
-  /* line 294, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .navbar-form {
     width: auto;
     border: 0;
@@ -4726,146 +3897,120 @@ textarea.input-group-sm > .input-group-btn > .btn {
     box-shadow: none;
   }
 }
-/* line 309, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-nav > li > .dropdown-menu {
   margin-top: 0;
   border-top-right-radius: 0;
   border-top-left-radius: 0;
 }
-/* line 314, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-fixed-bottom .navbar-nav > li > .dropdown-menu {
   border-bottom-right-radius: 0;
   border-bottom-left-radius: 0;
 }
-/* line 319, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-nav.pull-right > li > .dropdown-menu,
 .navbar-nav > li > .dropdown-menu.pull-right {
   left: auto;
   right: 0;
 }
-/* line 330, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-btn {
   margin-top: 6px;
   margin-bottom: 6px;
 }
-/* line 339, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-text {
   float: left;
   margin-top: 13px;
   margin-bottom: 13px;
 }
 @media (min-width: 768px) {
-  /* line 343, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .navbar-text {
     margin-left: 15px;
     margin-right: 15px;
   }
 }
-/* line 353, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-default {
   background-color: #ffffff;
   border-color: #eeeeee;
 }
-/* line 357, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-default .navbar-brand {
   color: #777777;
 }
-/* line 359, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-default .navbar-brand:hover,
 .navbar-default .navbar-brand:focus {
   color: #5e5e5e;
   background-color: transparent;
 }
-/* line 366, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-default .navbar-text {
   color: #777777;
 }
-/* line 371, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-default .navbar-nav > li > a {
   color: #777777;
 }
-/* line 374, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-default .navbar-nav > li > a:hover,
 .navbar-default .navbar-nav > li > a:focus {
   color: #333333;
   background-color: transparent;
 }
-/* line 381, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-default .navbar-nav > .active > a,
 .navbar-default .navbar-nav > .active > a:hover,
 .navbar-default .navbar-nav > .active > a:focus {
   color: #555555;
   background-color: #eeeeee;
 }
-/* line 389, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-default .navbar-nav > .disabled > a,
 .navbar-default .navbar-nav > .disabled > a:hover,
 .navbar-default .navbar-nav > .disabled > a:focus {
   color: #cccccc;
   background-color: transparent;
 }
-/* line 398, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-default .navbar-toggle {
   border-color: #dddddd;
 }
-/* line 400, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-default .navbar-toggle:hover,
 .navbar-default .navbar-toggle:focus {
   background-color: #dddddd;
 }
-/* line 404, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-default .navbar-toggle .icon-bar {
   background-color: #cccccc;
 }
-/* line 409, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-default .navbar-collapse,
 .navbar-default .navbar-form {
   border-color: #ededed;
 }
-/* line 417, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-default .navbar-nav > .dropdown > a:hover .caret,
 .navbar-default .navbar-nav > .dropdown > a:focus .caret {
   border-top-color: #333333;
   border-bottom-color: #333333;
 }
-/* line 425, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-default .navbar-nav > .open > a,
 .navbar-default .navbar-nav > .open > a:hover,
 .navbar-default .navbar-nav > .open > a:focus {
   background-color: #eeeeee;
   color: #555555;
 }
-/* line 430, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-default .navbar-nav > .open > a .caret,
 .navbar-default .navbar-nav > .open > a:hover .caret,
 .navbar-default .navbar-nav > .open > a:focus .caret {
   border-top-color: #555555;
   border-bottom-color: #555555;
 }
-/* line 436, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-default .navbar-nav > .dropdown > a .caret {
   border-top-color: #777777;
   border-bottom-color: #777777;
 }
 @media (max-width: 767px) {
-  /* line 445, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .navbar-default .navbar-nav .open .dropdown-menu > li > a {
     color: #777777;
   }
-  /* line 447, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .navbar-default .navbar-nav .open .dropdown-menu > li > a:hover,
   .navbar-default .navbar-nav .open .dropdown-menu > li > a:focus {
     color: #333333;
     background-color: transparent;
   }
-  /* line 454, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .navbar-default .navbar-nav .open .dropdown-menu > .active > a,
   .navbar-default .navbar-nav .open .dropdown-menu > .active > a:hover,
   .navbar-default .navbar-nav .open .dropdown-menu > .active > a:focus {
     color: #555555;
     background-color: #eeeeee;
   }
-  /* line 462, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a,
   .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a:hover,
   .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a:focus {
@@ -4873,93 +4018,75 @@ textarea.input-group-sm > .input-group-btn > .btn {
     background-color: transparent;
   }
 }
-/* line 478, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-default .navbar-link {
   color: #777777;
 }
-/* line 480, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-default .navbar-link:hover {
   color: #333333;
 }
-/* line 489, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-inverse {
   background-color: #222222;
   border-color: #080808;
 }
-/* line 493, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-inverse .navbar-brand {
   color: #999999;
 }
-/* line 495, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-inverse .navbar-brand:hover,
 .navbar-inverse .navbar-brand:focus {
   color: #ffffff;
   background-color: transparent;
 }
-/* line 502, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-inverse .navbar-text {
   color: #999999;
 }
-/* line 507, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-inverse .navbar-nav > li > a {
   color: #999999;
 }
-/* line 510, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-inverse .navbar-nav > li > a:hover,
 .navbar-inverse .navbar-nav > li > a:focus {
   color: #ffffff;
   background-color: transparent;
 }
-/* line 517, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-inverse .navbar-nav > .active > a,
 .navbar-inverse .navbar-nav > .active > a:hover,
 .navbar-inverse .navbar-nav > .active > a:focus {
   color: #ffffff;
   background-color: #080808;
 }
-/* line 525, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-inverse .navbar-nav > .disabled > a,
 .navbar-inverse .navbar-nav > .disabled > a:hover,
 .navbar-inverse .navbar-nav > .disabled > a:focus {
   color: #444444;
   background-color: transparent;
 }
-/* line 535, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-inverse .navbar-toggle {
   border-color: #333333;
 }
-/* line 537, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-inverse .navbar-toggle:hover,
 .navbar-inverse .navbar-toggle:focus {
   background-color: #333333;
 }
-/* line 541, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-inverse .navbar-toggle .icon-bar {
   background-color: #ffffff;
 }
-/* line 546, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-inverse .navbar-collapse,
 .navbar-inverse .navbar-form {
   border-color: #101010;
 }
-/* line 554, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-inverse .navbar-nav > .open > a,
 .navbar-inverse .navbar-nav > .open > a:hover,
 .navbar-inverse .navbar-nav > .open > a:focus {
   background-color: #080808;
   color: #ffffff;
 }
-/* line 561, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-inverse .navbar-nav > .dropdown > a:hover .caret {
   border-top-color: #ffffff;
   border-bottom-color: #ffffff;
 }
-/* line 565, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-inverse .navbar-nav > .dropdown > a .caret {
   border-top-color: #999999;
   border-bottom-color: #999999;
 }
-/* line 573, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-inverse .navbar-nav > .open > a .caret,
 .navbar-inverse .navbar-nav > .open > a:hover .caret,
 .navbar-inverse .navbar-nav > .open > a:focus .caret {
@@ -4967,28 +4094,23 @@ textarea.input-group-sm > .input-group-btn > .btn {
   border-bottom-color: #ffffff;
 }
 @media (max-width: 767px) {
-  /* line 583, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .navbar-inverse .navbar-nav .open .dropdown-menu > .dropdown-header {
     border-color: #080808;
   }
-  /* line 586, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .navbar-inverse .navbar-nav .open .dropdown-menu > li > a {
     color: #999999;
   }
-  /* line 588, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .navbar-inverse .navbar-nav .open .dropdown-menu > li > a:hover,
   .navbar-inverse .navbar-nav .open .dropdown-menu > li > a:focus {
     color: #ffffff;
     background-color: transparent;
   }
-  /* line 595, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .navbar-inverse .navbar-nav .open .dropdown-menu > .active > a,
   .navbar-inverse .navbar-nav .open .dropdown-menu > .active > a:hover,
   .navbar-inverse .navbar-nav .open .dropdown-menu > .active > a:focus {
     color: #ffffff;
     background-color: #080808;
   }
-  /* line 603, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .navbar-inverse .navbar-nav .open .dropdown-menu > .disabled > a,
   .navbar-inverse .navbar-nav .open .dropdown-menu > .disabled > a:hover,
   .navbar-inverse .navbar-nav .open .dropdown-menu > .disabled > a:focus {
@@ -4996,15 +4118,12 @@ textarea.input-group-sm > .input-group-btn > .btn {
     background-color: transparent;
   }
 }
-/* line 614, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-inverse .navbar-link {
   color: #999999;
 }
-/* line 616, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .navbar-inverse .navbar-link:hover {
   color: #ffffff;
 }
-/* line 6, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/breadcrumbs.less */
 .breadcrumb {
   padding: 8px 15px;
   margin-bottom: 20px;
@@ -5012,32 +4131,26 @@ textarea.input-group-sm > .input-group-btn > .btn {
   background-color: transparent;
   border-radius: 4px;
 }
-/* line 12, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/breadcrumbs.less */
 .breadcrumb > li {
   display: inline-block;
 }
-/* line 14, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/breadcrumbs.less */
 .breadcrumb > li + li:before {
   content: "/\00a0";
   padding: 0 5px;
   color: #cccccc;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/breadcrumbs.less */
 .breadcrumb > .active {
   color: #999999;
 }
-/* line 4, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/pagination.less */
 .pagination {
   display: inline-block;
   padding-left: 0;
   margin: 20px 0;
   border-radius: 4px;
 }
-/* line 10, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/pagination.less */
 .pagination > li {
   display: inline;
 }
-/* line 12, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/pagination.less */
 .pagination > li > a,
 .pagination > li > span {
   position: relative;
@@ -5049,27 +4162,23 @@ textarea.input-group-sm > .input-group-btn > .btn {
   border: 1px solid #cccccc;
   margin-left: -1px;
 }
-/* line 24, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/pagination.less */
 .pagination > li:first-child > a,
 .pagination > li:first-child > span {
   margin-left: 0;
   border-bottom-left-radius: 4px;
   border-top-left-radius: 4px;
 }
-/* line 31, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/pagination.less */
 .pagination > li:last-child > a,
 .pagination > li:last-child > span {
   border-bottom-right-radius: 4px;
   border-top-right-radius: 4px;
 }
-/* line 40, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/pagination.less */
 .pagination > li > a:hover,
 .pagination > li > span:hover,
 .pagination > li > a:focus,
 .pagination > li > span:focus {
   background-color: #eeeeee;
 }
-/* line 48, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/pagination.less */
 .pagination > .active > a,
 .pagination > .active > span,
 .pagination > .active > a:hover,
@@ -5082,7 +4191,6 @@ textarea.input-group-sm > .input-group-btn > .btn {
   border-color: #eeeeee;
   cursor: default;
 }
-/* line 60, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/pagination.less */
 .pagination > .disabled > span,
 .pagination > .disabled > a,
 .pagination > .disabled > a:hover,
@@ -5092,50 +4200,42 @@ textarea.input-group-sm > .input-group-btn > .btn {
   border-color: #cccccc;
   cursor: not-allowed;
 }
-/* line 453, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .pagination-lg > li > a,
 .pagination-lg > li > span {
   padding: 10px 16px;
   font-size: 18px;
 }
-/* line 459, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .pagination-lg > li:first-child > a,
 .pagination-lg > li:first-child > span {
   border-bottom-left-radius: 6px;
   border-top-left-radius: 6px;
 }
-/* line 465, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .pagination-lg > li:last-child > a,
 .pagination-lg > li:last-child > span {
   border-bottom-right-radius: 6px;
   border-top-right-radius: 6px;
 }
-/* line 453, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .pagination-sm > li > a,
 .pagination-sm > li > span {
   padding: 5px 10px;
   font-size: 12px;
 }
-/* line 459, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .pagination-sm > li:first-child > a,
 .pagination-sm > li:first-child > span {
   border-bottom-left-radius: 3px;
   border-top-left-radius: 3px;
 }
-/* line 465, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .pagination-sm > li:last-child > a,
 .pagination-sm > li:last-child > span {
   border-bottom-right-radius: 3px;
   border-top-right-radius: 3px;
 }
-/* line 6, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/pager.less */
 .pager {
   padding-left: 0;
   margin: 20px 0;
   list-style: none;
   text-align: center;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .pager:before,
 .pager:after {
   content: " ";
@@ -5145,11 +4245,9 @@ textarea.input-group-sm > .input-group-btn > .btn {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .pager:after {
   clear: both;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .pager:before,
 .pager:after {
   content: " ";
@@ -5159,15 +4257,12 @@ textarea.input-group-sm > .input-group-btn > .btn {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .pager:after {
   clear: both;
 }
-/* line 12, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/pager.less */
 .pager li {
   display: inline;
 }
-/* line 14, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/pager.less */
 .pager li > a,
 .pager li > span {
   display: inline-block;
@@ -5176,23 +4271,19 @@ textarea.input-group-sm > .input-group-btn > .btn {
   border: 1px solid #cccccc;
   border-radius: 15px;
 }
-/* line 23, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/pager.less */
 .pager li > a:hover,
 .pager li > a:focus {
   text-decoration: none;
   background-color: #eeeeee;
 }
-/* line 31, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/pager.less */
 .pager .next > a,
 .pager .next > span {
   float: right;
 }
-/* line 38, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/pager.less */
 .pager .previous > a,
 .pager .previous > span {
   float: left;
 }
-/* line 45, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/pager.less */
 .pager .disabled > a,
 .pager .disabled > a:hover,
 .pager .disabled > a:focus,
@@ -5201,7 +4292,6 @@ textarea.input-group-sm > .input-group-btn > .btn {
   background-color: #ffffff;
   cursor: not-allowed;
 }
-/* line 5, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/labels.less */
 .label {
   display: inline;
   padding: .2em .6em .3em;
@@ -5214,72 +4304,57 @@ textarea.input-group-sm > .input-group-btn > .btn {
   vertical-align: baseline;
   border-radius: .25em;
 }
-/* line 19, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/labels.less */
 .label[href]:hover,
 .label[href]:focus {
   color: #ffffff;
   text-decoration: none;
   cursor: pointer;
 }
-/* line 28, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/labels.less */
 .label:empty {
   display: none;
 }
-/* line 36, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/labels.less */
 .label-default {
   background-color: #999999;
 }
-/* line 478, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .label-default[href]:hover,
 .label-default[href]:focus {
   background-color: #808080;
 }
-/* line 40, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/labels.less */
 .label-primary {
   background-color: #428bca;
 }
-/* line 478, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .label-primary[href]:hover,
 .label-primary[href]:focus {
   background-color: #3071a9;
 }
-/* line 44, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/labels.less */
 .label-success {
   background-color: #5cb85c;
 }
-/* line 478, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .label-success[href]:hover,
 .label-success[href]:focus {
   background-color: #449d44;
 }
-/* line 48, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/labels.less */
 .label-info {
   background-color: #5bc0de;
 }
-/* line 478, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .label-info[href]:hover,
 .label-info[href]:focus {
   background-color: #31b0d5;
 }
-/* line 52, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/labels.less */
 .label-warning {
   background-color: #f0ad4e;
 }
-/* line 478, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .label-warning[href]:hover,
 .label-warning[href]:focus {
   background-color: #ec971f;
 }
-/* line 56, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/labels.less */
 .label-danger {
   background-color: #d9534f;
 }
-/* line 478, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .label-danger[href]:hover,
 .label-danger[href]:focus {
   background-color: #c9302c;
 }
-/* line 7, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/badges.less */
 .badge {
   display: inline-block;
   min-width: 10px;
@@ -5294,33 +4369,27 @@ textarea.input-group-sm > .input-group-btn > .btn {
   background-color: #999999;
   border-radius: 10px;
 }
-/* line 22, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/badges.less */
 .badge:empty {
   display: none;
 }
-/* line 29, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/badges.less */
 a.badge:hover,
 a.badge:focus {
   color: #ffffff;
   text-decoration: none;
   cursor: pointer;
 }
-/* line 38, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/badges.less */
 .btn .badge {
   position: relative;
   top: -1px;
 }
-/* line 44, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/badges.less */
 a.list-group-item.active > .badge,
 .nav-pills > .active > a > .badge {
   color: #428bca;
   background-color: #ffffff;
 }
-/* line 49, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/badges.less */
 .nav-pills > li > a > .badge {
   margin-left: 3px;
 }
-/* line 6, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/jumbotron.less */
 .jumbotron {
   padding: 30px;
   margin-bottom: 30px;
@@ -5330,38 +4399,31 @@ a.list-group-item.active > .badge,
   color: inherit;
   background-color: none;
 }
-/* line 15, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/jumbotron.less */
 .jumbotron h1 {
   line-height: 1;
   color: inherit;
 }
-/* line 19, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/jumbotron.less */
 .jumbotron p {
   line-height: 1.4;
 }
-/* line 23, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/jumbotron.less */
 .container .jumbotron,
 .wrap .jumbotron {
   border-radius: 6px;
 }
 @media screen and (min-width: 768px) {
-  /* line 27, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/jumbotron.less */
   .jumbotron {
     padding-top: 48px;
     padding-bottom: 48px;
   }
-  /* line 31, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/jumbotron.less */
   .container .jumbotron,
   .wrap .jumbotron {
     padding-left: 60px;
     padding-right: 60px;
   }
-  /* line 36, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/jumbotron.less */
   .jumbotron h1 {
     font-size: 63px;
   }
 }
-/* line 7, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/thumbnails.less */
 .thumbnail {
   padding: 4px;
   line-height: 1.428571429;
@@ -5375,160 +4437,128 @@ a.list-group-item.active > .badge,
   height: auto;
   display: block;
 }
-/* line 11, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/thumbnails.less */
 .thumbnail > img {
   display: block;
   max-width: 100%;
   height: auto;
 }
-/* line 18, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/thumbnails.less */
 a.thumbnail:hover,
 a.thumbnail:focus {
   border-color: #428bca;
 }
-/* line 24, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/thumbnails.less */
 .thumbnail > img {
   margin-left: auto;
   margin-right: auto;
 }
-/* line 28, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/thumbnails.less */
 .thumbnail .caption {
   padding: 9px;
   color: #333333;
 }
-/* line 9, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/alerts.less */
 .alert {
   padding: 15px;
   margin-bottom: 20px;
   border: 1px solid transparent;
   border-radius: 4px;
 }
-/* line 16, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/alerts.less */
 .alert h4 {
   margin-top: 0;
   color: inherit;
 }
-/* line 22, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/alerts.less */
 .alert .alert-link {
   font-weight: bold;
 }
-/* line 27, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/alerts.less */
 .alert > p,
 .alert > ul {
   margin-bottom: 0;
 }
-/* line 31, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/alerts.less */
 .alert > p + p {
   margin-top: 5px;
 }
-/* line 40, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/alerts.less */
 .alert-dismissable {
   padding-right: 35px;
 }
-/* line 44, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/alerts.less */
 .alert-dismissable .close {
   position: relative;
   top: -2px;
   right: -21px;
   color: inherit;
 }
-/* line 56, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/alerts.less */
 .alert-success {
   background-color: #dff0d8;
   border-color: #d6e9c6;
   color: #468847;
 }
-/* line 366, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .alert-success hr {
   border-top-color: #c9e2b3;
 }
-/* line 369, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .alert-success .alert-link {
   color: #356635;
 }
-/* line 59, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/alerts.less */
 .alert-info {
   background-color: #d9edf7;
   border-color: #bce8f1;
   color: #3a87ad;
 }
-/* line 366, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .alert-info hr {
   border-top-color: #a6e1ec;
 }
-/* line 369, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .alert-info .alert-link {
   color: #2d6987;
 }
-/* line 62, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/alerts.less */
 .alert-warning {
   background-color: #fcf8e3;
   border-color: #fbeed5;
   color: #c09853;
 }
-/* line 366, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .alert-warning hr {
   border-top-color: #f8e5be;
 }
-/* line 369, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .alert-warning .alert-link {
   color: #a47e3c;
 }
-/* line 65, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/alerts.less */
 .alert-danger {
   background-color: #f2dede;
   border-color: #eed3d7;
   color: #b94a48;
 }
-/* line 366, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .alert-danger hr {
   border-top-color: #e6c1c7;
 }
-/* line 369, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .alert-danger .alert-link {
   color: #953b39;
 }
 @-webkit-keyframes progress-bar-stripes {
-  /* line 11, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/progress-bars.less */
   from {
     background-position: 40px 0;
   }
-  /* line 12, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/progress-bars.less */
   to {
     background-position: 0 0;
   }
 }
 @-moz-keyframes progress-bar-stripes {
-  /* line 17, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/progress-bars.less */
   from {
     background-position: 40px 0;
   }
-  /* line 18, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/progress-bars.less */
   to {
     background-position: 0 0;
   }
 }
 @-o-keyframes progress-bar-stripes {
-  /* line 23, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/progress-bars.less */
   from {
     background-position: 0 0;
   }
-  /* line 24, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/progress-bars.less */
   to {
     background-position: 40px 0;
   }
 }
 @keyframes progress-bar-stripes {
-  /* line 29, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/progress-bars.less */
   from {
     background-position: 40px 0;
   }
-  /* line 30, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/progress-bars.less */
   to {
     background-position: 0 0;
   }
 }
-/* line 39, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/progress-bars.less */
 .progress {
   overflow: hidden;
   height: 20px;
@@ -5538,7 +4568,6 @@ a.thumbnail:focus {
   -webkit-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
 }
-/* line 49, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/progress-bars.less */
 .progress-bar {
   float: left;
   width: 0%;
@@ -5552,7 +4581,6 @@ a.thumbnail:focus {
   -webkit-transition: width 0.6s ease;
   transition: width 0.6s ease;
 }
-/* line 62, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/progress-bars.less */
 .progress-striped .progress-bar {
   background-image: -webkit-gradient(linear, 0 100%, 100% 0, color-stop(0.25, rgba(255, 255, 255, 0.15)), color-stop(0.25, transparent), color-stop(0.5, transparent), color-stop(0.5, rgba(255, 255, 255, 0.15)), color-stop(0.75, rgba(255, 255, 255, 0.15)), color-stop(0.75, transparent), to(transparent));
   background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
@@ -5560,7 +4588,6 @@ a.thumbnail:focus {
   background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
   background-size: 40px 40px;
 }
-/* line 68, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/progress-bars.less */
 .progress.active .progress-bar {
   -webkit-animation: progress-bar-stripes 2s linear infinite;
   -moz-animation: progress-bar-stripes 2s linear infinite;
@@ -5568,92 +4595,74 @@ a.thumbnail:focus {
   -o-animation: progress-bar-stripes 2s linear infinite;
   animation: progress-bar-stripes 2s linear infinite;
 }
-/* line 81, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/progress-bars.less */
 .progress-bar-success {
   background-color: #5cb85c;
 }
-/* line 498, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .progress-striped .progress-bar-success {
   background-image: -webkit-gradient(linear, 0 100%, 100% 0, color-stop(0.25, rgba(255, 255, 255, 0.15)), color-stop(0.25, transparent), color-stop(0.5, transparent), color-stop(0.5, rgba(255, 255, 255, 0.15)), color-stop(0.75, rgba(255, 255, 255, 0.15)), color-stop(0.75, transparent), to(transparent));
   background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
   background-image: -moz-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
   background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
 }
-/* line 85, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/progress-bars.less */
 .progress-bar-info {
   background-color: #5bc0de;
 }
-/* line 498, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .progress-striped .progress-bar-info {
   background-image: -webkit-gradient(linear, 0 100%, 100% 0, color-stop(0.25, rgba(255, 255, 255, 0.15)), color-stop(0.25, transparent), color-stop(0.5, transparent), color-stop(0.5, rgba(255, 255, 255, 0.15)), color-stop(0.75, rgba(255, 255, 255, 0.15)), color-stop(0.75, transparent), to(transparent));
   background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
   background-image: -moz-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
   background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
 }
-/* line 89, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/progress-bars.less */
 .progress-bar-warning {
   background-color: #f0ad4e;
 }
-/* line 498, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .progress-striped .progress-bar-warning {
   background-image: -webkit-gradient(linear, 0 100%, 100% 0, color-stop(0.25, rgba(255, 255, 255, 0.15)), color-stop(0.25, transparent), color-stop(0.5, transparent), color-stop(0.5, rgba(255, 255, 255, 0.15)), color-stop(0.75, rgba(255, 255, 255, 0.15)), color-stop(0.75, transparent), to(transparent));
   background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
   background-image: -moz-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
   background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
 }
-/* line 93, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/progress-bars.less */
 .progress-bar-danger {
   background-color: #d9534f;
 }
-/* line 498, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .progress-striped .progress-bar-danger {
   background-image: -webkit-gradient(linear, 0 100%, 100% 0, color-stop(0.25, rgba(255, 255, 255, 0.15)), color-stop(0.25, transparent), color-stop(0.5, transparent), color-stop(0.5, rgba(255, 255, 255, 0.15)), color-stop(0.75, rgba(255, 255, 255, 0.15)), color-stop(0.75, transparent), to(transparent));
   background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
   background-image: -moz-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
   background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
 }
-/* line 10, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/media.less */
 .media,
 .media-body {
   overflow: hidden;
   zoom: 1;
 }
-/* line 17, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/media.less */
 .media,
 .media .media {
   margin-top: 15px;
 }
-/* line 21, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/media.less */
 .media:first-child {
   margin-top: 0;
 }
-/* line 26, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/media.less */
 .media-object {
   display: block;
 }
-/* line 31, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/media.less */
 .media-heading {
   margin: 0 0 5px;
 }
-/* line 40, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/media.less */
 .media > .pull-left {
   margin-right: 10px;
 }
-/* line 43, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/media.less */
 .media > .pull-right {
   margin-left: 10px;
 }
-/* line 53, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/media.less */
 .media-list {
   padding-left: 0;
   list-style: none;
 }
-/* line 8, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/list-group.less */
 .list-group {
   margin-bottom: 20px;
   padding-left: 0;
 }
-/* line 17, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/list-group.less */
 .list-group-item {
   position: relative;
   display: block;
@@ -5662,40 +4671,32 @@ a.thumbnail:focus {
   background-color: #ffffff;
   border: 1px solid #dddddd;
 }
-/* line 27, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/list-group.less */
 .list-group-item:first-child {
   border-top-right-radius: 4px;
   border-top-left-radius: 4px;
 }
-/* line 30, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/list-group.less */
 .list-group-item:last-child {
   margin-bottom: 0;
   border-bottom-right-radius: 4px;
   border-bottom-left-radius: 4px;
 }
-/* line 36, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/list-group.less */
 .list-group-item > .badge {
   float: right;
 }
-/* line 39, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/list-group.less */
 .list-group-item > .badge + .badge {
   margin-right: 5px;
 }
-/* line 44, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/list-group.less */
 a.list-group-item {
   color: #555555;
 }
-/* line 47, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/list-group.less */
 a.list-group-item .list-group-item-heading {
   color: #333333;
 }
-/* line 52, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/list-group.less */
 a.list-group-item:hover,
 a.list-group-item:focus {
   text-decoration: none;
   background-color: #f5f5f5;
 }
-/* line 60, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/list-group.less */
 .list-group-item.active,
 .list-group-item.active:hover,
 .list-group-item.active:focus {
@@ -5704,29 +4705,24 @@ a.list-group-item:focus {
   background-color: #428bca;
   border-color: #428bca;
 }
-/* line 69, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/list-group.less */
 .list-group-item.active .list-group-item-heading,
 .list-group-item.active:hover .list-group-item-heading,
 .list-group-item.active:focus .list-group-item-heading {
   color: inherit;
 }
-/* line 72, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/list-group.less */
 .list-group-item.active .list-group-item-text,
 .list-group-item.active:hover .list-group-item-text,
 .list-group-item.active:focus .list-group-item-text {
   color: #e1edf7;
 }
-/* line 81, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/list-group.less */
 .list-group-item-heading {
   margin-top: 0;
   margin-bottom: 5px;
 }
-/* line 85, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/list-group.less */
 .list-group-item-text {
   margin-bottom: 0;
   line-height: 1.3;
 }
-/* line 7, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/panels.less */
 .panel {
   margin-bottom: 20px;
   background-color: #ffffff;
@@ -5735,11 +4731,9 @@ a.list-group-item:focus {
   -webkit-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
 }
-/* line 16, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/panels.less */
 .panel-body {
   padding: 15px;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .panel-body:before,
 .panel-body:after {
   content: " ";
@@ -5749,11 +4743,9 @@ a.list-group-item:focus {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .panel-body:after {
   clear: both;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .panel-body:before,
 .panel-body:after {
   content: " ";
@@ -5763,59 +4755,47 @@ a.list-group-item:focus {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .panel-body:after {
   clear: both;
 }
-/* line 28, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/panels.less */
 .panel > .list-group {
   margin-bottom: 0;
 }
-/* line 31, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/panels.less */
 .panel > .list-group .list-group-item {
   border-width: 1px 0;
 }
-/* line 35, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/panels.less */
 .panel > .list-group .list-group-item:first-child {
   border-top-right-radius: 0;
   border-top-left-radius: 0;
 }
-/* line 39, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/panels.less */
 .panel > .list-group .list-group-item:last-child {
   border-bottom: 0;
 }
-/* line 47, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/panels.less */
 .panel-heading + .list-group .list-group-item:first-child {
   border-top-width: 0;
 }
-/* line 59, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/panels.less */
 .panel > .table,
 .panel > table {
   margin-bottom: 0;
 }
-/* line 62, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/panels.less */
 .panel > .panel-body + .table,
 .panel > .panel-body + table {
   border-top: 1px solid #e8e8e8;
 }
-/* line 69, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/panels.less */
 .panel-heading {
   padding: 10px 15px;
   border-bottom: 1px solid transparent;
   border-top-right-radius: 3px;
   border-top-left-radius: 3px;
 }
-/* line 76, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/panels.less */
 .panel-title {
   margin-top: 0;
   margin-bottom: 0;
   font-size: 16px;
 }
-/* line 80, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/panels.less */
 .panel-title > a {
   color: inherit;
 }
-/* line 86, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/panels.less */
 .panel-footer {
   padding: 10px 15px;
   background-color: #f5f5f5;
@@ -5823,141 +4803,110 @@ a.list-group-item:focus {
   border-bottom-right-radius: 3px;
   border-bottom-left-radius: 3px;
 }
-/* line 101, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/panels.less */
 .panel-group .panel {
   margin-bottom: 0;
   border-radius: 4px;
   overflow: hidden;
 }
-/* line 105, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/panels.less */
 .panel-group .panel + .panel {
   margin-top: 5px;
 }
-/* line 110, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/panels.less */
 .panel-group .panel-heading {
   border-bottom: 0;
 }
-/* line 112, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/panels.less */
 .panel-group .panel-heading + .panel-collapse .panel-body {
   border-top: 1px solid #dddddd;
 }
-/* line 116, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/panels.less */
 .panel-group .panel-footer {
   border-top: 0;
 }
-/* line 118, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/panels.less */
 .panel-group .panel-footer + .panel-collapse .panel-body {
   border-bottom: 1px solid #dddddd;
 }
-/* line 131, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/panels.less */
 .panel-default {
   border-color: #dddddd;
 }
-/* line 345, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .panel-default > .panel-heading {
   color: #333333;
   background-color: #f5f5f5;
   border-color: #dddddd;
 }
-/* line 349, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .panel-default > .panel-heading + .panel-collapse .panel-body {
   border-top-color: #dddddd;
 }
-/* line 354, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .panel-default > .panel-footer + .panel-collapse .panel-body {
   border-bottom-color: #dddddd;
 }
-/* line 134, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/panels.less */
 .panel-primary {
   border-color: #428bca;
 }
-/* line 345, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .panel-primary > .panel-heading {
   color: #ffffff;
   background-color: #428bca;
   border-color: #428bca;
 }
-/* line 349, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .panel-primary > .panel-heading + .panel-collapse .panel-body {
   border-top-color: #428bca;
 }
-/* line 354, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .panel-primary > .panel-footer + .panel-collapse .panel-body {
   border-bottom-color: #428bca;
 }
-/* line 137, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/panels.less */
 .panel-success {
   border-color: #d6e9c6;
 }
-/* line 345, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .panel-success > .panel-heading {
   color: #468847;
   background-color: #dff0d8;
   border-color: #d6e9c6;
 }
-/* line 349, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .panel-success > .panel-heading + .panel-collapse .panel-body {
   border-top-color: #d6e9c6;
 }
-/* line 354, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .panel-success > .panel-footer + .panel-collapse .panel-body {
   border-bottom-color: #d6e9c6;
 }
-/* line 140, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/panels.less */
 .panel-warning {
   border-color: #fbeed5;
 }
-/* line 345, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .panel-warning > .panel-heading {
   color: #c09853;
   background-color: #fcf8e3;
   border-color: #fbeed5;
 }
-/* line 349, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .panel-warning > .panel-heading + .panel-collapse .panel-body {
   border-top-color: #fbeed5;
 }
-/* line 354, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .panel-warning > .panel-footer + .panel-collapse .panel-body {
   border-bottom-color: #fbeed5;
 }
-/* line 143, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/panels.less */
 .panel-danger {
   border-color: #eed3d7;
 }
-/* line 345, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .panel-danger > .panel-heading {
   color: #b94a48;
   background-color: #f2dede;
   border-color: #eed3d7;
 }
-/* line 349, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .panel-danger > .panel-heading + .panel-collapse .panel-body {
   border-top-color: #eed3d7;
 }
-/* line 354, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .panel-danger > .panel-footer + .panel-collapse .panel-body {
   border-bottom-color: #eed3d7;
 }
-/* line 146, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/panels.less */
 .panel-info {
   border-color: #bce8f1;
 }
-/* line 345, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .panel-info > .panel-heading {
   color: #3a87ad;
   background-color: #d9edf7;
   border-color: #bce8f1;
 }
-/* line 349, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .panel-info > .panel-heading + .panel-collapse .panel-body {
   border-top-color: #bce8f1;
 }
-/* line 354, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .panel-info > .panel-footer + .panel-collapse .panel-body {
   border-bottom-color: #bce8f1;
 }
-/* line 7, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/wells.less */
 .well {
   min-height: 20px;
   padding: 19px;
@@ -5968,22 +4917,18 @@ a.list-group-item:focus {
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
 }
-/* line 15, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/wells.less */
 .well blockquote {
   border-color: #ddd;
   border-color: rgba(0, 0, 0, 0.15);
 }
-/* line 22, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/wells.less */
 .well-lg {
   padding: 24px;
   border-radius: 6px;
 }
-/* line 26, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/wells.less */
 .well-sm {
   padding: 9px;
   border-radius: 3px;
 }
-/* line 6, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/close.less */
 .close {
   float: right;
   font-size: 21px;
@@ -5994,7 +4939,6 @@ a.list-group-item:focus {
   opacity: 0.2;
   filter: alpha(opacity=20);
 }
-/* line 15, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/close.less */
 .close:hover,
 .close:focus {
   color: #000000;
@@ -6003,7 +4947,6 @@ a.list-group-item:focus {
   opacity: 0.5;
   filter: alpha(opacity=50);
 }
-/* line 26, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/close.less */
 button.close {
   padding: 0;
   cursor: pointer;
@@ -6011,17 +4954,14 @@ button.close {
   border: 0;
   -webkit-appearance: none;
 }
-/* line 11, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/modals.less */
 .modal-open {
   overflow: hidden;
 }
-/* line 16, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/modals.less */
 body.modal-open,
 .modal-open .navbar-fixed-top,
 .modal-open .navbar-fixed-bottom {
   margin-right: 15px;
 }
-/* line 24, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/modals.less */
 .modal {
   display: none;
   overflow: auto;
@@ -6033,7 +4973,6 @@ body.modal-open,
   left: 0;
   z-index: 1040;
 }
-/* line 36, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/modals.less */
 .modal.fade .modal-dialog {
   -webkit-transform: translate(0, -25%);
   -ms-transform: translate(0, -25%);
@@ -6043,13 +4982,11 @@ body.modal-open,
   -o-transition: -o-transform 0.3s ease-out;
   transition: transform 0.3s ease-out;
 }
-/* line 40, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/modals.less */
 .modal.in .modal-dialog {
   -webkit-transform: translate(0, 0);
   -ms-transform: translate(0, 0);
   transform: translate(0, 0);
 }
-/* line 44, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/modals.less */
 .modal-dialog {
   margin-left: auto;
   margin-right: auto;
@@ -6057,7 +4994,6 @@ body.modal-open,
   padding: 10px;
   z-index: 1050;
 }
-/* line 53, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/modals.less */
 .modal-content {
   position: relative;
   background-color: #ffffff;
@@ -6069,7 +5005,6 @@ body.modal-open,
   background-clip: padding-box;
   outline: none;
 }
-/* line 66, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/modals.less */
 .modal-backdrop {
   position: fixed;
   top: 0;
@@ -6079,44 +5014,36 @@ body.modal-open,
   z-index: 1030;
   background-color: #000000;
 }
-/* line 75, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/modals.less */
 .modal-backdrop.fade {
   opacity: 0;
   filter: alpha(opacity=0);
 }
-/* line 76, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/modals.less */
 .modal-backdrop.in {
   opacity: 0.5;
   filter: alpha(opacity=50);
 }
-/* line 81, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/modals.less */
 .modal-header {
   padding: 15px;
   border-bottom: 1px solid #e5e5e5;
   min-height: 16.428571429px;
 }
-/* line 87, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/modals.less */
 .modal-header .close {
   margin-top: -2px;
 }
-/* line 92, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/modals.less */
 .modal-title {
   margin: 0;
   line-height: 1.428571429;
 }
-/* line 99, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/modals.less */
 .modal-body {
   position: relative;
   padding: 20px;
 }
-/* line 105, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/modals.less */
 .modal-footer {
   margin-top: 15px;
   padding: 19px 20px 20px;
   text-align: right;
   border-top: 1px solid #e5e5e5;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .modal-footer:before,
 .modal-footer:after {
   content: " ";
@@ -6126,11 +5053,9 @@ body.modal-open,
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .modal-footer:after {
   clear: both;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .modal-footer:before,
 .modal-footer:after {
   content: " ";
@@ -6140,25 +5065,20 @@ body.modal-open,
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .modal-footer:after {
   clear: both;
 }
-/* line 113, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/modals.less */
 .modal-footer .btn + .btn {
   margin-left: 5px;
   margin-bottom: 0;
 }
-/* line 118, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/modals.less */
 .modal-footer .btn-group .btn + .btn {
   margin-left: -1px;
 }
-/* line 122, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/modals.less */
 .modal-footer .btn-block + .btn-block {
   margin-left: 0;
 }
 @media screen and (min-width: 768px) {
-  /* line 130, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/modals.less */
   .modal-dialog {
     left: 50%;
     right: auto;
@@ -6166,13 +5086,11 @@ body.modal-open,
     padding-top: 30px;
     padding-bottom: 30px;
   }
-  /* line 137, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/modals.less */
   .modal-content {
     -webkit-box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
     box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
   }
 }
-/* line 7, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tooltip.less */
 .tooltip {
   position: absolute;
   z-index: 1030;
@@ -6183,32 +5101,26 @@ body.modal-open,
   opacity: 0;
   filter: alpha(opacity=0);
 }
-/* line 16, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tooltip.less */
 .tooltip.in {
   opacity: 0.9;
   filter: alpha(opacity=90);
 }
-/* line 17, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tooltip.less */
 .tooltip.top {
   margin-top: -3px;
   padding: 5px 0;
 }
-/* line 18, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tooltip.less */
 .tooltip.right {
   margin-left: 3px;
   padding: 0 5px;
 }
-/* line 19, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tooltip.less */
 .tooltip.bottom {
   margin-top: 3px;
   padding: 5px 0;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tooltip.less */
 .tooltip.left {
   margin-left: -3px;
   padding: 0 5px;
 }
-/* line 24, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tooltip.less */
 .tooltip-inner {
   max-width: 200px;
   padding: 3px 8px;
@@ -6218,7 +5130,6 @@ body.modal-open,
   background-color: #000000;
   border-radius: 4px;
 }
-/* line 35, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tooltip.less */
 .tooltip-arrow {
   position: absolute;
   width: 0;
@@ -6226,7 +5137,6 @@ body.modal-open,
   border-color: transparent;
   border-style: solid;
 }
-/* line 43, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tooltip.less */
 .tooltip.top .tooltip-arrow {
   bottom: 0;
   left: 50%;
@@ -6234,21 +5144,18 @@ body.modal-open,
   border-width: 5px 5px 0;
   border-top-color: #000000;
 }
-/* line 50, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tooltip.less */
 .tooltip.top-left .tooltip-arrow {
   bottom: 0;
   left: 5px;
   border-width: 5px 5px 0;
   border-top-color: #000000;
 }
-/* line 56, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tooltip.less */
 .tooltip.top-right .tooltip-arrow {
   bottom: 0;
   right: 5px;
   border-width: 5px 5px 0;
   border-top-color: #000000;
 }
-/* line 62, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tooltip.less */
 .tooltip.right .tooltip-arrow {
   top: 50%;
   left: 0;
@@ -6256,7 +5163,6 @@ body.modal-open,
   border-width: 5px 5px 5px 0;
   border-right-color: #000000;
 }
-/* line 69, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tooltip.less */
 .tooltip.left .tooltip-arrow {
   top: 50%;
   right: 0;
@@ -6264,7 +5170,6 @@ body.modal-open,
   border-width: 5px 0 5px 5px;
   border-left-color: #000000;
 }
-/* line 76, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tooltip.less */
 .tooltip.bottom .tooltip-arrow {
   top: 0;
   left: 50%;
@@ -6272,21 +5177,18 @@ body.modal-open,
   border-width: 0 5px 5px;
   border-bottom-color: #000000;
 }
-/* line 83, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tooltip.less */
 .tooltip.bottom-left .tooltip-arrow {
   top: 0;
   left: 5px;
   border-width: 0 5px 5px;
   border-bottom-color: #000000;
 }
-/* line 89, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tooltip.less */
 .tooltip.bottom-right .tooltip-arrow {
   top: 0;
   right: 5px;
   border-width: 0 5px 5px;
   border-bottom-color: #000000;
 }
-/* line 6, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/popovers.less */
 .popover {
   position: absolute;
   top: 0;
@@ -6305,23 +5207,18 @@ body.modal-open,
   box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
   white-space: normal;
 }
-/* line 26, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/popovers.less */
 .popover.top {
   margin-top: -10px;
 }
-/* line 27, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/popovers.less */
 .popover.right {
   margin-left: 10px;
 }
-/* line 28, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/popovers.less */
 .popover.bottom {
   margin-top: 10px;
 }
-/* line 29, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/popovers.less */
 .popover.left {
   margin-left: -10px;
 }
-/* line 32, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/popovers.less */
 .popover-title {
   margin: 0;
   padding: 8px 14px;
@@ -6332,11 +5229,9 @@ body.modal-open,
   border-bottom: 1px solid #ebebeb;
   border-radius: 5px 5px 0 0;
 }
-/* line 43, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/popovers.less */
 .popover-content {
   padding: 9px 14px;
 }
-/* line 52, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/popovers.less */
 .popover .arrow,
 .popover .arrow:after {
   position: absolute;
@@ -6346,16 +5241,13 @@ body.modal-open,
   border-color: transparent;
   border-style: solid;
 }
-/* line 62, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/popovers.less */
 .popover .arrow {
   border-width: 11px;
 }
-/* line 65, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/popovers.less */
 .popover .arrow:after {
   border-width: 10px;
   content: "";
 }
-/* line 71, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/popovers.less */
 .popover.top .arrow {
   left: 50%;
   margin-left: -11px;
@@ -6364,7 +5256,6 @@ body.modal-open,
   border-top-color: rgba(0, 0, 0, 0.25);
   bottom: -11px;
 }
-/* line 78, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/popovers.less */
 .popover.top .arrow:after {
   content: " ";
   bottom: 1px;
@@ -6372,7 +5263,6 @@ body.modal-open,
   border-bottom-width: 0;
   border-top-color: #ffffff;
 }
-/* line 86, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/popovers.less */
 .popover.right .arrow {
   top: 50%;
   left: -11px;
@@ -6381,7 +5271,6 @@ body.modal-open,
   border-right-color: #999999;
   border-right-color: rgba(0, 0, 0, 0.25);
 }
-/* line 93, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/popovers.less */
 .popover.right .arrow:after {
   content: " ";
   left: 1px;
@@ -6389,7 +5278,6 @@ body.modal-open,
   border-left-width: 0;
   border-right-color: #ffffff;
 }
-/* line 101, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/popovers.less */
 .popover.bottom .arrow {
   left: 50%;
   margin-left: -11px;
@@ -6398,7 +5286,6 @@ body.modal-open,
   border-bottom-color: rgba(0, 0, 0, 0.25);
   top: -11px;
 }
-/* line 108, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/popovers.less */
 .popover.bottom .arrow:after {
   content: " ";
   top: 1px;
@@ -6406,7 +5293,6 @@ body.modal-open,
   border-top-width: 0;
   border-bottom-color: #ffffff;
 }
-/* line 117, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/popovers.less */
 .popover.left .arrow {
   top: 50%;
   right: -11px;
@@ -6415,7 +5301,6 @@ body.modal-open,
   border-left-color: #999999;
   border-left-color: rgba(0, 0, 0, 0.25);
 }
-/* line 124, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/popovers.less */
 .popover.left .arrow:after {
   content: " ";
   right: 1px;
@@ -6423,24 +5308,20 @@ body.modal-open,
   border-left-color: #ffffff;
   bottom: -10px;
 }
-/* line 7, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/carousel.less */
 .carousel {
   position: relative;
 }
-/* line 11, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/carousel.less */
 .carousel-inner {
   position: relative;
   overflow: hidden;
   width: 100%;
 }
-/* line 16, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/carousel.less */
 .carousel-inner > .item {
   display: none;
   position: relative;
   -webkit-transition: 0.6s ease-in-out left;
   transition: 0.6s ease-in-out left;
 }
-/* line 22, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/carousel.less */
 .carousel-inner > .item > img,
 .carousel-inner > .item > a > img {
   display: block;
@@ -6448,45 +5329,36 @@ body.modal-open,
   height: auto;
   line-height: 1;
 }
-/* line 29, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/carousel.less */
 .carousel-inner > .active,
 .carousel-inner > .next,
 .carousel-inner > .prev {
   display: block;
 }
-/* line 33, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/carousel.less */
 .carousel-inner > .active {
   left: 0;
 }
-/* line 37, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/carousel.less */
 .carousel-inner > .next,
 .carousel-inner > .prev {
   position: absolute;
   top: 0;
   width: 100%;
 }
-/* line 44, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/carousel.less */
 .carousel-inner > .next {
   left: 100%;
 }
-/* line 47, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/carousel.less */
 .carousel-inner > .prev {
   left: -100%;
 }
-/* line 50, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/carousel.less */
 .carousel-inner > .next.left,
 .carousel-inner > .prev.right {
   left: 0;
 }
-/* line 55, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/carousel.less */
 .carousel-inner > .active.left {
   left: -100%;
 }
-/* line 58, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/carousel.less */
 .carousel-inner > .active.right {
   left: 100%;
 }
-/* line 67, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/carousel.less */
 .carousel-control {
   position: absolute;
   top: 0;
@@ -6500,7 +5372,6 @@ body.modal-open,
   text-align: center;
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
 }
-/* line 82, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/carousel.less */
 .carousel-control.left {
   background-image: -webkit-gradient(linear, 0% top, 100% top, from(rgba(0, 0, 0, 0.5)), to(rgba(0, 0, 0, 0.0001)));
   background-image: -webkit-linear-gradient(left, color-stop(rgba(0, 0, 0, 0.5) 0%), color-stop(rgba(0, 0, 0, 0.0001) 100%));
@@ -6509,7 +5380,6 @@ body.modal-open,
   background-repeat: repeat-x;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#80000000', endColorstr='#00000000', GradientType=1);
 }
-/* line 85, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/carousel.less */
 .carousel-control.right {
   left: auto;
   right: 0;
@@ -6520,7 +5390,6 @@ body.modal-open,
   background-repeat: repeat-x;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#00000000', endColorstr='#80000000', GradientType=1);
 }
-/* line 92, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/carousel.less */
 .carousel-control:hover,
 .carousel-control:focus {
   color: #ffffff;
@@ -6528,7 +5397,6 @@ body.modal-open,
   opacity: 0.9;
   filter: alpha(opacity=90);
 }
-/* line 100, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/carousel.less */
 .carousel-control .icon-prev,
 .carousel-control .icon-next,
 .carousel-control .glyphicon-chevron-left,
@@ -6539,7 +5407,6 @@ body.modal-open,
   z-index: 5;
   display: inline-block;
 }
-/* line 110, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/carousel.less */
 .carousel-control .icon-prev,
 .carousel-control .icon-next {
   width: 20px;
@@ -6548,15 +5415,12 @@ body.modal-open,
   margin-left: -10px;
   font-family: serif;
 }
-/* line 120, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/carousel.less */
 .carousel-control .icon-prev:before {
   content: '\2039';
 }
-/* line 125, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/carousel.less */
 .carousel-control .icon-next:before {
   content: '\203a';
 }
-/* line 136, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/carousel.less */
 .carousel-indicators {
   position: absolute;
   bottom: 10px;
@@ -6568,7 +5432,6 @@ body.modal-open,
   list-style: none;
   text-align: center;
 }
-/* line 147, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/carousel.less */
 .carousel-indicators li {
   display: inline-block;
   width: 10px;
@@ -6579,14 +5442,12 @@ body.modal-open,
   border-radius: 10px;
   cursor: pointer;
 }
-/* line 157, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/carousel.less */
 .carousel-indicators .active {
   margin: 0;
   width: 12px;
   height: 12px;
   background-color: #ffffff;
 }
-/* line 168, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/carousel.less */
 .carousel-caption {
   position: absolute;
   left: 15%;
@@ -6599,12 +5460,10 @@ body.modal-open,
   text-align: center;
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
 }
-/* line 179, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/carousel.less */
 .carousel-caption .btn {
   text-shadow: none;
 }
 @media screen and (min-width: 768px) {
-  /* line 189, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/carousel.less */
   .carousel-control .icon-prev,
   .carousel-control .icon-next {
     width: 30px;
@@ -6613,18 +5472,15 @@ body.modal-open,
     margin-left: -15px;
     font-size: 30px;
   }
-  /* line 199, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/carousel.less */
   .carousel-caption {
     left: 20%;
     right: 20%;
     padding-bottom: 30px;
   }
-  /* line 206, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/carousel.less */
   .carousel-indicators {
     bottom: 20px;
   }
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .clearfix:before,
 .clearfix:after {
   content: " ";
@@ -6634,31 +5490,24 @@ body.modal-open,
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .clearfix:after {
   clear: both;
 }
-/* line 12, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/utilities.less */
 .pull-right {
   float: right !important;
 }
-/* line 15, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/utilities.less */
 .pull-left {
   float: left !important;
 }
-/* line 23, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/utilities.less */
 .hide {
   display: none !important;
 }
-/* line 26, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/utilities.less */
 .show {
   display: block !important;
 }
-/* line 29, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/utilities.less */
 .invisible {
   visibility: hidden;
 }
-/* line 32, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/utilities.less */
 .text-hide {
   font: 0/0 a;
   color: transparent;
@@ -6666,7 +5515,6 @@ body.modal-open,
   background-color: transparent;
   border: 0;
 }
-/* line 40, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/utilities.less */
 .affix {
   position: fixed;
 }
@@ -6678,631 +5526,501 @@ body.modal-open,
     width: 320px;
   }
 }
-/* line 31, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
 .hidden {
   display: none !important;
   visibility: hidden !important;
 }
-/* line 38, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
 .visible-xs {
   display: none !important;
 }
-/* line 515, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 tr.visible-xs {
   display: none !important;
 }
-/* line 516, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 th.visible-xs,
 td.visible-xs {
   display: none !important;
 }
 @media (max-width: 767px) {
-  /* line 40, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
   .visible-xs {
     display: block !important;
   }
-  /* line 508, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   tr.visible-xs {
     display: table-row !important;
   }
-  /* line 509, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   th.visible-xs,
   td.visible-xs {
     display: table-cell !important;
   }
 }
 @media (min-width: 768px) and (max-width: 991px) {
-  /* line 44, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
   .visible-xs.visible-sm {
     display: block !important;
   }
-  /* line 508, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   tr.visible-xs.visible-sm {
     display: table-row !important;
   }
-  /* line 509, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   th.visible-xs.visible-sm,
   td.visible-xs.visible-sm {
     display: table-cell !important;
   }
 }
 @media (min-width: 992px) and (max-width: 1199px) {
-  /* line 49, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
   .visible-xs.visible-md {
     display: block !important;
   }
-  /* line 508, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   tr.visible-xs.visible-md {
     display: table-row !important;
   }
-  /* line 509, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   th.visible-xs.visible-md,
   td.visible-xs.visible-md {
     display: table-cell !important;
   }
 }
 @media (min-width: 1200px) {
-  /* line 54, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
   .visible-xs.visible-lg {
     display: block !important;
   }
-  /* line 508, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   tr.visible-xs.visible-lg {
     display: table-row !important;
   }
-  /* line 509, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   th.visible-xs.visible-lg,
   td.visible-xs.visible-lg {
     display: table-cell !important;
   }
 }
-/* line 59, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
 .visible-sm {
   display: none !important;
 }
-/* line 515, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 tr.visible-sm {
   display: none !important;
 }
-/* line 516, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 th.visible-sm,
 td.visible-sm {
   display: none !important;
 }
 @media (max-width: 767px) {
-  /* line 62, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
   .visible-sm.visible-xs {
     display: block !important;
   }
-  /* line 508, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   tr.visible-sm.visible-xs {
     display: table-row !important;
   }
-  /* line 509, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   th.visible-sm.visible-xs,
   td.visible-sm.visible-xs {
     display: table-cell !important;
   }
 }
 @media (min-width: 768px) and (max-width: 991px) {
-  /* line 66, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
   .visible-sm {
     display: block !important;
   }
-  /* line 508, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   tr.visible-sm {
     display: table-row !important;
   }
-  /* line 509, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   th.visible-sm,
   td.visible-sm {
     display: table-cell !important;
   }
 }
 @media (min-width: 992px) and (max-width: 1199px) {
-  /* line 70, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
   .visible-sm.visible-md {
     display: block !important;
   }
-  /* line 508, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   tr.visible-sm.visible-md {
     display: table-row !important;
   }
-  /* line 509, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   th.visible-sm.visible-md,
   td.visible-sm.visible-md {
     display: table-cell !important;
   }
 }
 @media (min-width: 1200px) {
-  /* line 75, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
   .visible-sm.visible-lg {
     display: block !important;
   }
-  /* line 508, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   tr.visible-sm.visible-lg {
     display: table-row !important;
   }
-  /* line 509, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   th.visible-sm.visible-lg,
   td.visible-sm.visible-lg {
     display: table-cell !important;
   }
 }
-/* line 80, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
 .visible-md {
   display: none !important;
 }
-/* line 515, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 tr.visible-md {
   display: none !important;
 }
-/* line 516, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 th.visible-md,
 td.visible-md {
   display: none !important;
 }
 @media (max-width: 767px) {
-  /* line 83, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
   .visible-md.visible-xs {
     display: block !important;
   }
-  /* line 508, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   tr.visible-md.visible-xs {
     display: table-row !important;
   }
-  /* line 509, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   th.visible-md.visible-xs,
   td.visible-md.visible-xs {
     display: table-cell !important;
   }
 }
 @media (min-width: 768px) and (max-width: 991px) {
-  /* line 88, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
   .visible-md.visible-sm {
     display: block !important;
   }
-  /* line 508, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   tr.visible-md.visible-sm {
     display: table-row !important;
   }
-  /* line 509, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   th.visible-md.visible-sm,
   td.visible-md.visible-sm {
     display: table-cell !important;
   }
 }
 @media (min-width: 992px) and (max-width: 1199px) {
-  /* line 92, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
   .visible-md {
     display: block !important;
   }
-  /* line 508, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   tr.visible-md {
     display: table-row !important;
   }
-  /* line 509, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   th.visible-md,
   td.visible-md {
     display: table-cell !important;
   }
 }
 @media (min-width: 1200px) {
-  /* line 96, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
   .visible-md.visible-lg {
     display: block !important;
   }
-  /* line 508, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   tr.visible-md.visible-lg {
     display: table-row !important;
   }
-  /* line 509, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   th.visible-md.visible-lg,
   td.visible-md.visible-lg {
     display: table-cell !important;
   }
 }
-/* line 101, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
 .visible-lg {
   display: none !important;
 }
-/* line 515, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 tr.visible-lg {
   display: none !important;
 }
-/* line 516, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 th.visible-lg,
 td.visible-lg {
   display: none !important;
 }
 @media (max-width: 767px) {
-  /* line 104, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
   .visible-lg.visible-xs {
     display: block !important;
   }
-  /* line 508, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   tr.visible-lg.visible-xs {
     display: table-row !important;
   }
-  /* line 509, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   th.visible-lg.visible-xs,
   td.visible-lg.visible-xs {
     display: table-cell !important;
   }
 }
 @media (min-width: 768px) and (max-width: 991px) {
-  /* line 109, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
   .visible-lg.visible-sm {
     display: block !important;
   }
-  /* line 508, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   tr.visible-lg.visible-sm {
     display: table-row !important;
   }
-  /* line 509, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   th.visible-lg.visible-sm,
   td.visible-lg.visible-sm {
     display: table-cell !important;
   }
 }
 @media (min-width: 992px) and (max-width: 1199px) {
-  /* line 114, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
   .visible-lg.visible-md {
     display: block !important;
   }
-  /* line 508, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   tr.visible-lg.visible-md {
     display: table-row !important;
   }
-  /* line 509, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   th.visible-lg.visible-md,
   td.visible-lg.visible-md {
     display: table-cell !important;
   }
 }
 @media (min-width: 1200px) {
-  /* line 118, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
   .visible-lg {
     display: block !important;
   }
-  /* line 508, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   tr.visible-lg {
     display: table-row !important;
   }
-  /* line 509, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   th.visible-lg,
   td.visible-lg {
     display: table-cell !important;
   }
 }
-/* line 123, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
 .hidden-xs {
   display: block !important;
 }
-/* line 508, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 tr.hidden-xs {
   display: table-row !important;
 }
-/* line 509, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 th.hidden-xs,
 td.hidden-xs {
   display: table-cell !important;
 }
 @media (max-width: 767px) {
-  /* line 125, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
   .hidden-xs {
     display: none !important;
   }
-  /* line 515, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   tr.hidden-xs {
     display: none !important;
   }
-  /* line 516, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   th.hidden-xs,
   td.hidden-xs {
     display: none !important;
   }
 }
 @media (min-width: 768px) and (max-width: 991px) {
-  /* line 129, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
   .hidden-xs.hidden-sm {
     display: none !important;
   }
-  /* line 515, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   tr.hidden-xs.hidden-sm {
     display: none !important;
   }
-  /* line 516, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   th.hidden-xs.hidden-sm,
   td.hidden-xs.hidden-sm {
     display: none !important;
   }
 }
 @media (min-width: 992px) and (max-width: 1199px) {
-  /* line 134, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
   .hidden-xs.hidden-md {
     display: none !important;
   }
-  /* line 515, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   tr.hidden-xs.hidden-md {
     display: none !important;
   }
-  /* line 516, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   th.hidden-xs.hidden-md,
   td.hidden-xs.hidden-md {
     display: none !important;
   }
 }
 @media (min-width: 1200px) {
-  /* line 139, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
   .hidden-xs.hidden-lg {
     display: none !important;
   }
-  /* line 515, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   tr.hidden-xs.hidden-lg {
     display: none !important;
   }
-  /* line 516, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   th.hidden-xs.hidden-lg,
   td.hidden-xs.hidden-lg {
     display: none !important;
   }
 }
-/* line 144, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
 .hidden-sm {
   display: block !important;
 }
-/* line 508, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 tr.hidden-sm {
   display: table-row !important;
 }
-/* line 509, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 th.hidden-sm,
 td.hidden-sm {
   display: table-cell !important;
 }
 @media (max-width: 767px) {
-  /* line 147, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
   .hidden-sm.hidden-xs {
     display: none !important;
   }
-  /* line 515, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   tr.hidden-sm.hidden-xs {
     display: none !important;
   }
-  /* line 516, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   th.hidden-sm.hidden-xs,
   td.hidden-sm.hidden-xs {
     display: none !important;
   }
 }
 @media (min-width: 768px) and (max-width: 991px) {
-  /* line 151, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
   .hidden-sm {
     display: none !important;
   }
-  /* line 515, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   tr.hidden-sm {
     display: none !important;
   }
-  /* line 516, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   th.hidden-sm,
   td.hidden-sm {
     display: none !important;
   }
 }
 @media (min-width: 992px) and (max-width: 1199px) {
-  /* line 155, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
   .hidden-sm.hidden-md {
     display: none !important;
   }
-  /* line 515, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   tr.hidden-sm.hidden-md {
     display: none !important;
   }
-  /* line 516, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   th.hidden-sm.hidden-md,
   td.hidden-sm.hidden-md {
     display: none !important;
   }
 }
 @media (min-width: 1200px) {
-  /* line 160, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
   .hidden-sm.hidden-lg {
     display: none !important;
   }
-  /* line 515, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   tr.hidden-sm.hidden-lg {
     display: none !important;
   }
-  /* line 516, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   th.hidden-sm.hidden-lg,
   td.hidden-sm.hidden-lg {
     display: none !important;
   }
 }
-/* line 165, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
 .hidden-md {
   display: block !important;
 }
-/* line 508, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 tr.hidden-md {
   display: table-row !important;
 }
-/* line 509, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 th.hidden-md,
 td.hidden-md {
   display: table-cell !important;
 }
 @media (max-width: 767px) {
-  /* line 168, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
   .hidden-md.hidden-xs {
     display: none !important;
   }
-  /* line 515, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   tr.hidden-md.hidden-xs {
     display: none !important;
   }
-  /* line 516, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   th.hidden-md.hidden-xs,
   td.hidden-md.hidden-xs {
     display: none !important;
   }
 }
 @media (min-width: 768px) and (max-width: 991px) {
-  /* line 173, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
   .hidden-md.hidden-sm {
     display: none !important;
   }
-  /* line 515, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   tr.hidden-md.hidden-sm {
     display: none !important;
   }
-  /* line 516, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   th.hidden-md.hidden-sm,
   td.hidden-md.hidden-sm {
     display: none !important;
   }
 }
 @media (min-width: 992px) and (max-width: 1199px) {
-  /* line 177, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
   .hidden-md {
     display: none !important;
   }
-  /* line 515, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   tr.hidden-md {
     display: none !important;
   }
-  /* line 516, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   th.hidden-md,
   td.hidden-md {
     display: none !important;
   }
 }
 @media (min-width: 1200px) {
-  /* line 181, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
   .hidden-md.hidden-lg {
     display: none !important;
   }
-  /* line 515, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   tr.hidden-md.hidden-lg {
     display: none !important;
   }
-  /* line 516, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   th.hidden-md.hidden-lg,
   td.hidden-md.hidden-lg {
     display: none !important;
   }
 }
-/* line 186, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
 .hidden-lg {
   display: block !important;
 }
-/* line 508, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 tr.hidden-lg {
   display: table-row !important;
 }
-/* line 509, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 th.hidden-lg,
 td.hidden-lg {
   display: table-cell !important;
 }
 @media (max-width: 767px) {
-  /* line 189, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
   .hidden-lg.hidden-xs {
     display: none !important;
   }
-  /* line 515, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   tr.hidden-lg.hidden-xs {
     display: none !important;
   }
-  /* line 516, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   th.hidden-lg.hidden-xs,
   td.hidden-lg.hidden-xs {
     display: none !important;
   }
 }
 @media (min-width: 768px) and (max-width: 991px) {
-  /* line 194, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
   .hidden-lg.hidden-sm {
     display: none !important;
   }
-  /* line 515, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   tr.hidden-lg.hidden-sm {
     display: none !important;
   }
-  /* line 516, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   th.hidden-lg.hidden-sm,
   td.hidden-lg.hidden-sm {
     display: none !important;
   }
 }
 @media (min-width: 992px) and (max-width: 1199px) {
-  /* line 199, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
   .hidden-lg.hidden-md {
     display: none !important;
   }
-  /* line 515, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   tr.hidden-lg.hidden-md {
     display: none !important;
   }
-  /* line 516, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   th.hidden-lg.hidden-md,
   td.hidden-lg.hidden-md {
     display: none !important;
   }
 }
 @media (min-width: 1200px) {
-  /* line 203, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
   .hidden-lg {
     display: none !important;
   }
-  /* line 515, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   tr.hidden-lg {
     display: none !important;
   }
-  /* line 516, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   th.hidden-lg,
   td.hidden-lg {
     display: none !important;
   }
 }
-/* line 209, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
 .visible-print {
   display: none !important;
 }
-/* line 515, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 tr.visible-print {
   display: none !important;
 }
-/* line 516, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 th.visible-print,
 td.visible-print {
   display: none !important;
 }
 @media print {
-  /* line 214, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
   .visible-print {
     display: block !important;
   }
-  /* line 508, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   tr.visible-print {
     display: table-row !important;
   }
-  /* line 509, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   th.visible-print,
   td.visible-print {
     display: table-cell !important;
   }
-  /* line 217, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/responsive-utilities.less */
   .hidden-print {
     display: none !important;
   }
-  /* line 515, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   tr.hidden-print {
     display: none !important;
   }
-  /* line 516, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   th.hidden-print,
   td.hidden-print {
     display: none !important;
@@ -7344,7 +6062,6 @@ td.visible-print {
 }
 /* FONT AWESOME CORE
  * -------------------------- */
-/* line 4, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/core.less */
 [class^="icon-"],
 [class*=" icon-"] {
   font-family: FontAwesome;
@@ -7354,7 +6071,6 @@ td.visible-print {
   -webkit-font-smoothing: antialiased;
   *margin-right: .3em;
 }
-/* line 9, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/core.less */
 [class^="icon-"]:before,
 [class*=" icon-"]:before {
   text-decoration: inherit;
@@ -7362,19 +6078,16 @@ td.visible-print {
   speak: none;
 }
 /* makes the font 33% larger relative to the icon container */
-/* line 17, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/core.less */
 .icon-large:before {
   vertical-align: -10%;
   font-size: 1.3333333333333333em;
 }
 /* makes sure icons active on rollover in links */
-/* line 24, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/core.less */
 a [class^="icon-"],
 a [class*=" icon-"] {
   display: inline;
 }
 /* increased font size for icon-large */
-/* line 33, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/core.less */
 [class^="icon-"].icon-fixed-width,
 [class*=" icon-"].icon-fixed-width {
   display: inline-block;
@@ -7382,21 +6095,17 @@ a [class*=" icon-"] {
   text-align: right;
   padding-right: 0.2857142857142857em;
 }
-/* line 38, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/core.less */
 [class^="icon-"].icon-fixed-width.icon-large,
 [class*=" icon-"].icon-fixed-width.icon-large {
   width: 1.4285714285714286em;
 }
-/* line 44, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/core.less */
 .icons-ul {
   margin-left: 2.142857142857143em;
   list-style-type: none;
 }
-/* line 48, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/core.less */
 .icons-ul > li {
   position: relative;
 }
-/* line 50, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/core.less */
 .icons-ul .icon-li {
   position: absolute;
   left: -2.142857142857143em;
@@ -7404,24 +6113,19 @@ a [class*=" icon-"] {
   text-align: center;
   line-height: inherit;
 }
-/* line 62, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/core.less */
 [class^="icon-"].hide,
 [class*=" icon-"].hide {
   display: none;
 }
-/* line 67, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/core.less */
 .icon-muted {
   color: #eeeeee;
 }
-/* line 68, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/core.less */
 .icon-light {
   color: #ffffff;
 }
-/* line 69, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/core.less */
 .icon-dark {
   color: #333333;
 }
-/* line 74, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/core.less */
 .icon-border {
   border: solid 1px #eeeeee;
   padding: .2em .25em .15em;
@@ -7429,64 +6133,52 @@ a [class*=" icon-"] {
   -moz-border-radius: 3px;
   border-radius: 3px;
 }
-/* line 83, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/core.less */
 .icon-2x {
   font-size: 2em;
 }
-/* line 85, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/core.less */
 .icon-2x.icon-border {
   border-width: 2px;
   -webkit-border-radius: 4px;
   -moz-border-radius: 4px;
   border-radius: 4px;
 }
-/* line 90, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/core.less */
 .icon-3x {
   font-size: 3em;
 }
-/* line 92, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/core.less */
 .icon-3x.icon-border {
   border-width: 3px;
   -webkit-border-radius: 5px;
   -moz-border-radius: 5px;
   border-radius: 5px;
 }
-/* line 97, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/core.less */
 .icon-4x {
   font-size: 4em;
 }
-/* line 99, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/core.less */
 .icon-4x.icon-border {
   border-width: 4px;
   -webkit-border-radius: 6px;
   -moz-border-radius: 6px;
   border-radius: 6px;
 }
-/* line 105, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/core.less */
 .icon-5x {
   font-size: 5em;
 }
-/* line 107, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/core.less */
 .icon-5x.icon-border {
   border-width: 5px;
   -webkit-border-radius: 7px;
   -moz-border-radius: 7px;
   border-radius: 7px;
 }
-/* line 118, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/core.less */
 .pull-right {
   float: right;
 }
-/* line 119, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/core.less */
 .pull-left {
   float: left;
 }
-/* line 123, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/core.less */
 [class^="icon-"].pull-left,
 [class*=" icon-"].pull-left {
   margin-right: .3em;
 }
-/* line 126, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/core.less */
 [class^="icon-"].pull-right,
 [class*=" icon-"].pull-right {
   margin-left: .3em;
@@ -7494,7 +6186,6 @@ a [class*=" icon-"] {
 /* BOOTSTRAP SPECIFIC CLASSES
  * -------------------------- */
 /* Bootstrap 2.0 sprites.less reset */
-/* line 5, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/bootstrap.less */
 [class^="icon-"],
 [class*=" icon-"] {
   display: inline;
@@ -7508,7 +6199,6 @@ a [class*=" icon-"] {
   margin-top: 0;
 }
 /* more sprites.less reset */
-/* line 19, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/bootstrap.less */
 .icon-white,
 .nav-pills > .active > a > [class^="icon-"],
 .nav-pills > .active > a > [class*=" icon-"],
@@ -7525,21 +6215,18 @@ a [class*=" icon-"] {
   background-image: none;
 }
 /* keeps Bootstrap styles with and without icons the same */
-/* line 41, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/bootstrap.less */
 .btn [class^="icon-"].icon-large,
 .nav [class^="icon-"].icon-large,
 .btn [class*=" icon-"].icon-large,
 .nav [class*=" icon-"].icon-large {
   line-height: .9em;
 }
-/* line 42, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/bootstrap.less */
 .btn [class^="icon-"].icon-spin,
 .nav [class^="icon-"].icon-spin,
 .btn [class*=" icon-"].icon-spin,
 .nav [class*=" icon-"].icon-spin {
   display: inline-block;
 }
-/* line 48, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/bootstrap.less */
 .nav-tabs [class^="icon-"],
 .nav-pills [class^="icon-"],
 .nav-tabs [class*=" icon-"],
@@ -7550,49 +6237,41 @@ a [class*=" icon-"] {
 .nav-pills [class*=" icon-"].icon-large {
   line-height: .9em;
 }
-/* line 55, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/bootstrap.less */
 .btn [class^="icon-"].pull-left.icon-2x,
 .btn [class*=" icon-"].pull-left.icon-2x,
 .btn [class^="icon-"].pull-right.icon-2x,
 .btn [class*=" icon-"].pull-right.icon-2x {
   margin-top: .18em;
 }
-/* line 57, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/bootstrap.less */
 .btn [class^="icon-"].icon-spin.icon-large,
 .btn [class*=" icon-"].icon-spin.icon-large {
   line-height: .8em;
 }
-/* line 64, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/bootstrap.less */
 .btn.btn-small [class^="icon-"].pull-left.icon-2x,
 .btn.btn-small [class*=" icon-"].pull-left.icon-2x,
 .btn.btn-small [class^="icon-"].pull-right.icon-2x,
 .btn.btn-small [class*=" icon-"].pull-right.icon-2x {
   margin-top: .25em;
 }
-/* line 69, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/bootstrap.less */
 .btn.btn-large [class^="icon-"],
 .btn.btn-large [class*=" icon-"] {
   margin-top: 0;
 }
-/* line 73, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/bootstrap.less */
 .btn.btn-large [class^="icon-"].pull-left.icon-2x,
 .btn.btn-large [class*=" icon-"].pull-left.icon-2x,
 .btn.btn-large [class^="icon-"].pull-right.icon-2x,
 .btn.btn-large [class*=" icon-"].pull-right.icon-2x {
   margin-top: .05em;
 }
-/* line 75, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/bootstrap.less */
 .btn.btn-large [class^="icon-"].pull-left.icon-2x,
 .btn.btn-large [class*=" icon-"].pull-left.icon-2x {
   margin-right: .2em;
 }
-/* line 76, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/bootstrap.less */
 .btn.btn-large [class^="icon-"].pull-right.icon-2x,
 .btn.btn-large [class*=" icon-"].pull-right.icon-2x {
   margin-left: .2em;
 }
 /* Fixes alignment in nav lists */
-/* line 81, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/bootstrap.less */
 .nav-list [class^="icon-"],
 .nav-list [class*=" icon-"] {
   line-height: inherit;
@@ -7600,7 +6279,6 @@ a [class*=" icon-"] {
 /* EXTRAS
  * -------------------------- */
 /* Stacked and layered icon */
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/mixins.less */
 .icon-stack {
   position: relative;
   display: inline-block;
@@ -7609,7 +6287,6 @@ a [class*=" icon-"] {
   line-height: 2em;
   vertical-align: -35%;
 }
-/* line 32, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/mixins.less */
 .icon-stack [class^="icon-"],
 .icon-stack [class*=" icon-"] {
   display: block;
@@ -7621,13 +6298,11 @@ a [class*=" icon-"] {
   line-height: inherit;
   *line-height: 2em;
 }
-/* line 43, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/mixins.less */
 .icon-stack .icon-stack-base {
   font-size: 2em;
   *line-height: 1em;
 }
 /* Animated rotating icon */
-/* line 8, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/extras.less */
 .icon-spin {
   display: inline-block;
   -moz-animation: spin 2s infinite linear;
@@ -7636,64 +6311,52 @@ a [class*=" icon-"] {
   animation: spin 2s infinite linear;
 }
 /* Prevent stack and spinners from being taken inline when inside a link */
-/* line 17, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/extras.less */
 a .icon-stack,
 a .icon-spin {
   display: inline-block;
   text-decoration: none;
 }
 @-moz-keyframes spin {
-  /* line 24, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/extras.less */
   0% {
     -moz-transform: rotate(0deg);
   }
-  /* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/extras.less */
   100% {
     -moz-transform: rotate(359deg);
   }
 }
 @-webkit-keyframes spin {
-  /* line 28, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/extras.less */
   0% {
     -webkit-transform: rotate(0deg);
   }
-  /* line 29, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/extras.less */
   100% {
     -webkit-transform: rotate(359deg);
   }
 }
 @-o-keyframes spin {
-  /* line 32, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/extras.less */
   0% {
     -o-transform: rotate(0deg);
   }
-  /* line 33, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/extras.less */
   100% {
     -o-transform: rotate(359deg);
   }
 }
 @-ms-keyframes spin {
-  /* line 36, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/extras.less */
   0% {
     -ms-transform: rotate(0deg);
   }
-  /* line 37, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/extras.less */
   100% {
     -ms-transform: rotate(359deg);
   }
 }
 @keyframes spin {
-  /* line 40, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/extras.less */
   0% {
     transform: rotate(0deg);
   }
-  /* line 41, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/extras.less */
   100% {
     transform: rotate(359deg);
   }
 }
 /* Icon rotations and mirroring */
-/* line 45, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/extras.less */
 .icon-rotate-90:before {
   -webkit-transform: rotate(90deg);
   -moz-transform: rotate(90deg);
@@ -7702,7 +6365,6 @@ a .icon-spin {
   transform: rotate(90deg);
   filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=1);
 }
-/* line 54, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/extras.less */
 .icon-rotate-180:before {
   -webkit-transform: rotate(180deg);
   -moz-transform: rotate(180deg);
@@ -7711,7 +6373,6 @@ a .icon-spin {
   transform: rotate(180deg);
   filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=2);
 }
-/* line 63, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/extras.less */
 .icon-rotate-270:before {
   -webkit-transform: rotate(270deg);
   -moz-transform: rotate(270deg);
@@ -7720,7 +6381,6 @@ a .icon-spin {
   transform: rotate(270deg);
   filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
 }
-/* line 72, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/extras.less */
 .icon-flip-horizontal:before {
   -webkit-transform: scale(-1, 1);
   -moz-transform: scale(-1, 1);
@@ -7728,7 +6388,6 @@ a .icon-spin {
   -o-transform: scale(-1, 1);
   transform: scale(-1, 1);
 }
-/* line 80, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/extras.less */
 .icon-flip-vertical:before {
   -webkit-transform: scale(1, -1);
   -moz-transform: scale(1, -1);
@@ -7737,7 +6396,6 @@ a .icon-spin {
   transform: scale(1, -1);
 }
 /* ensure rotation occurs inside anchor tags */
-/* line 91, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/extras.less */
 a .icon-rotate-90:before,
 a .icon-rotate-180:before,
 a .icon-rotate-270:before,
@@ -7747,1473 +6405,1110 @@ a .icon-flip-vertical:before {
 }
 /* Font Awesome uses the Unicode Private Use Area (PUA) to ensure screen
    readers do not read off random characters that represent icons */
-/* line 4, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-glass:before {
   content: "\f000";
 }
-/* line 5, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-music:before {
   content: "\f001";
 }
-/* line 6, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-search:before {
   content: "\f002";
 }
-/* line 7, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-envelope-alt:before {
   content: "\f003";
 }
-/* line 8, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-heart:before {
   content: "\f004";
 }
-/* line 9, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-star:before {
   content: "\f005";
 }
-/* line 10, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-star-empty:before {
   content: "\f006";
 }
-/* line 11, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-user:before {
   content: "\f007";
 }
-/* line 12, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-film:before {
   content: "\f008";
 }
-/* line 13, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-th-large:before {
   content: "\f009";
 }
-/* line 14, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-th:before {
   content: "\f00a";
 }
-/* line 15, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-th-list:before {
   content: "\f00b";
 }
-/* line 16, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-ok:before {
   content: "\f00c";
 }
-/* line 17, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-remove:before {
   content: "\f00d";
 }
-/* line 18, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-zoom-in:before {
   content: "\f00e";
 }
-/* line 19, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-zoom-out:before {
   content: "\f010";
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-power-off:before,
 .icon-off:before {
   content: "\f011";
 }
-/* line 22, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-signal:before {
   content: "\f012";
 }
-/* line 23, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-gear:before,
 .icon-cog:before {
   content: "\f013";
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-trash:before {
   content: "\f014";
 }
-/* line 26, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-home:before {
   content: "\f015";
 }
-/* line 27, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-file-alt:before {
   content: "\f016";
 }
-/* line 28, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-time:before {
   content: "\f017";
 }
-/* line 29, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-road:before {
   content: "\f018";
 }
-/* line 30, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-download-alt:before {
   content: "\f019";
 }
-/* line 31, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-download:before {
   content: "\f01a";
 }
-/* line 32, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-upload:before {
   content: "\f01b";
 }
-/* line 33, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-inbox:before {
   content: "\f01c";
 }
-/* line 34, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-play-circle:before {
   content: "\f01d";
 }
-/* line 35, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-rotate-right:before,
 .icon-repeat:before {
   content: "\f01e";
 }
-/* line 37, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-refresh:before {
   content: "\f021";
 }
-/* line 38, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-list-alt:before {
   content: "\f022";
 }
-/* line 39, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-lock:before {
   content: "\f023";
 }
-/* line 40, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-flag:before {
   content: "\f024";
 }
-/* line 41, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-headphones:before {
   content: "\f025";
 }
-/* line 42, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-volume-off:before {
   content: "\f026";
 }
-/* line 43, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-volume-down:before {
   content: "\f027";
 }
-/* line 44, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-volume-up:before {
   content: "\f028";
 }
-/* line 45, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-qrcode:before {
   content: "\f029";
 }
-/* line 46, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-barcode:before {
   content: "\f02a";
 }
-/* line 47, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-tag:before {
   content: "\f02b";
 }
-/* line 48, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-tags:before {
   content: "\f02c";
 }
-/* line 49, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-book:before {
   content: "\f02d";
 }
-/* line 50, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-bookmark:before {
   content: "\f02e";
 }
-/* line 51, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-print:before {
   content: "\f02f";
 }
-/* line 52, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-camera:before {
   content: "\f030";
 }
-/* line 53, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-font:before {
   content: "\f031";
 }
-/* line 54, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-bold:before {
   content: "\f032";
 }
-/* line 55, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-italic:before {
   content: "\f033";
 }
-/* line 56, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-text-height:before {
   content: "\f034";
 }
-/* line 57, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-text-width:before {
   content: "\f035";
 }
-/* line 58, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-align-left:before {
   content: "\f036";
 }
-/* line 59, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-align-center:before {
   content: "\f037";
 }
-/* line 60, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-align-right:before {
   content: "\f038";
 }
-/* line 61, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-align-justify:before {
   content: "\f039";
 }
-/* line 62, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-list:before {
   content: "\f03a";
 }
-/* line 63, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-indent-left:before {
   content: "\f03b";
 }
-/* line 64, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-indent-right:before {
   content: "\f03c";
 }
-/* line 65, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-facetime-video:before {
   content: "\f03d";
 }
-/* line 66, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-picture:before {
   content: "\f03e";
 }
-/* line 67, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-pencil:before {
   content: "\f040";
 }
-/* line 68, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-map-marker:before {
   content: "\f041";
 }
-/* line 69, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-adjust:before {
   content: "\f042";
 }
-/* line 70, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-tint:before {
   content: "\f043";
 }
-/* line 71, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-edit:before {
   content: "\f044";
 }
-/* line 72, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-share:before {
   content: "\f045";
 }
-/* line 73, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-check:before {
   content: "\f046";
 }
-/* line 74, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-move:before {
   content: "\f047";
 }
-/* line 75, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-step-backward:before {
   content: "\f048";
 }
-/* line 76, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-fast-backward:before {
   content: "\f049";
 }
-/* line 77, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-backward:before {
   content: "\f04a";
 }
-/* line 78, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-play:before {
   content: "\f04b";
 }
-/* line 79, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-pause:before {
   content: "\f04c";
 }
-/* line 80, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-stop:before {
   content: "\f04d";
 }
-/* line 81, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-forward:before {
   content: "\f04e";
 }
-/* line 82, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-fast-forward:before {
   content: "\f050";
 }
-/* line 83, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-step-forward:before {
   content: "\f051";
 }
-/* line 84, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-eject:before {
   content: "\f052";
 }
-/* line 85, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-chevron-left:before {
   content: "\f053";
 }
-/* line 86, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-chevron-right:before {
   content: "\f054";
 }
-/* line 87, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-plus-sign:before {
   content: "\f055";
 }
-/* line 88, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-minus-sign:before {
   content: "\f056";
 }
-/* line 89, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-remove-sign:before {
   content: "\f057";
 }
-/* line 90, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-ok-sign:before {
   content: "\f058";
 }
-/* line 91, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-question-sign:before {
   content: "\f059";
 }
-/* line 92, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-info-sign:before {
   content: "\f05a";
 }
-/* line 93, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-screenshot:before {
   content: "\f05b";
 }
-/* line 94, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-remove-circle:before {
   content: "\f05c";
 }
-/* line 95, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-ok-circle:before {
   content: "\f05d";
 }
-/* line 96, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-ban-circle:before {
   content: "\f05e";
 }
-/* line 97, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-arrow-left:before {
   content: "\f060";
 }
-/* line 98, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-arrow-right:before {
   content: "\f061";
 }
-/* line 99, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-arrow-up:before {
   content: "\f062";
 }
-/* line 100, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-arrow-down:before {
   content: "\f063";
 }
-/* line 101, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-mail-forward:before,
 .icon-share-alt:before {
   content: "\f064";
 }
-/* line 103, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-resize-full:before {
   content: "\f065";
 }
-/* line 104, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-resize-small:before {
   content: "\f066";
 }
-/* line 105, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-plus:before {
   content: "\f067";
 }
-/* line 106, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-minus:before {
   content: "\f068";
 }
-/* line 107, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-asterisk:before {
   content: "\f069";
 }
-/* line 108, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-exclamation-sign:before {
   content: "\f06a";
 }
-/* line 109, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-gift:before {
   content: "\f06b";
 }
-/* line 110, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-leaf:before {
   content: "\f06c";
 }
-/* line 111, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-fire:before {
   content: "\f06d";
 }
-/* line 112, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-eye-open:before {
   content: "\f06e";
 }
-/* line 113, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-eye-close:before {
   content: "\f070";
 }
-/* line 114, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-warning-sign:before {
   content: "\f071";
 }
-/* line 115, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-plane:before {
   content: "\f072";
 }
-/* line 116, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-calendar:before {
   content: "\f073";
 }
-/* line 117, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-random:before {
   content: "\f074";
 }
-/* line 118, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-comment:before {
   content: "\f075";
 }
-/* line 119, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-magnet:before {
   content: "\f076";
 }
-/* line 120, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-chevron-up:before {
   content: "\f077";
 }
-/* line 121, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-chevron-down:before {
   content: "\f078";
 }
-/* line 122, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-retweet:before {
   content: "\f079";
 }
-/* line 123, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-shopping-cart:before {
   content: "\f07a";
 }
-/* line 124, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-folder-close:before {
   content: "\f07b";
 }
-/* line 125, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-folder-open:before {
   content: "\f07c";
 }
-/* line 126, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-resize-vertical:before {
   content: "\f07d";
 }
-/* line 127, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-resize-horizontal:before {
   content: "\f07e";
 }
-/* line 128, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-bar-chart:before {
   content: "\f080";
 }
-/* line 129, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-twitter-sign:before {
   content: "\f081";
 }
-/* line 130, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-facebook-sign:before {
   content: "\f082";
 }
-/* line 131, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-camera-retro:before {
   content: "\f083";
 }
-/* line 132, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-key:before {
   content: "\f084";
 }
-/* line 133, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-gears:before,
 .icon-cogs:before {
   content: "\f085";
 }
-/* line 135, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-comments:before {
   content: "\f086";
 }
-/* line 136, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-thumbs-up-alt:before {
   content: "\f087";
 }
-/* line 137, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-thumbs-down-alt:before {
   content: "\f088";
 }
-/* line 138, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-star-half:before {
   content: "\f089";
 }
-/* line 139, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-heart-empty:before {
   content: "\f08a";
 }
-/* line 140, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-signout:before {
   content: "\f08b";
 }
-/* line 141, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-linkedin-sign:before {
   content: "\f08c";
 }
-/* line 142, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-pushpin:before {
   content: "\f08d";
 }
-/* line 143, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-external-link:before {
   content: "\f08e";
 }
-/* line 144, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-signin:before {
   content: "\f090";
 }
-/* line 145, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-trophy:before {
   content: "\f091";
 }
-/* line 146, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-github-sign:before {
   content: "\f092";
 }
-/* line 147, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-upload-alt:before {
   content: "\f093";
 }
-/* line 148, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-lemon:before {
   content: "\f094";
 }
-/* line 149, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-phone:before {
   content: "\f095";
 }
-/* line 150, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-unchecked:before,
 .icon-check-empty:before {
   content: "\f096";
 }
-/* line 152, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-bookmark-empty:before {
   content: "\f097";
 }
-/* line 153, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-phone-sign:before {
   content: "\f098";
 }
-/* line 154, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-twitter:before {
   content: "\f099";
 }
-/* line 155, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-facebook:before {
   content: "\f09a";
 }
-/* line 156, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-github:before {
   content: "\f09b";
 }
-/* line 157, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-unlock:before {
   content: "\f09c";
 }
-/* line 158, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-credit-card:before {
   content: "\f09d";
 }
-/* line 159, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-rss:before {
   content: "\f09e";
 }
-/* line 160, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-hdd:before {
   content: "\f0a0";
 }
-/* line 161, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-bullhorn:before {
   content: "\f0a1";
 }
-/* line 162, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-bell:before {
   content: "\f0a2";
 }
-/* line 163, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-certificate:before {
   content: "\f0a3";
 }
-/* line 164, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-hand-right:before {
   content: "\f0a4";
 }
-/* line 165, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-hand-left:before {
   content: "\f0a5";
 }
-/* line 166, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-hand-up:before {
   content: "\f0a6";
 }
-/* line 167, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-hand-down:before {
   content: "\f0a7";
 }
-/* line 168, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-circle-arrow-left:before {
   content: "\f0a8";
 }
-/* line 169, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-circle-arrow-right:before {
   content: "\f0a9";
 }
-/* line 170, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-circle-arrow-up:before {
   content: "\f0aa";
 }
-/* line 171, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-circle-arrow-down:before {
   content: "\f0ab";
 }
-/* line 172, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-globe:before {
   content: "\f0ac";
 }
-/* line 173, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-wrench:before {
   content: "\f0ad";
 }
-/* line 174, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-tasks:before {
   content: "\f0ae";
 }
-/* line 175, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-filter:before {
   content: "\f0b0";
 }
-/* line 176, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-briefcase:before {
   content: "\f0b1";
 }
-/* line 177, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-fullscreen:before {
   content: "\f0b2";
 }
-/* line 178, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-group:before {
   content: "\f0c0";
 }
-/* line 179, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-link:before {
   content: "\f0c1";
 }
-/* line 180, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-cloud:before {
   content: "\f0c2";
 }
-/* line 181, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-beaker:before {
   content: "\f0c3";
 }
-/* line 182, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-cut:before {
   content: "\f0c4";
 }
-/* line 183, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-copy:before {
   content: "\f0c5";
 }
-/* line 184, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-paperclip:before,
 .icon-paper-clip:before {
   content: "\f0c6";
 }
-/* line 186, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-save:before {
   content: "\f0c7";
 }
-/* line 187, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-sign-blank:before {
   content: "\f0c8";
 }
-/* line 188, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-reorder:before {
   content: "\f0c9";
 }
-/* line 189, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-list-ul:before {
   content: "\f0ca";
 }
-/* line 190, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-list-ol:before {
   content: "\f0cb";
 }
-/* line 191, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-strikethrough:before {
   content: "\f0cc";
 }
-/* line 192, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-underline:before {
   content: "\f0cd";
 }
-/* line 193, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-table:before {
   content: "\f0ce";
 }
-/* line 194, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-magic:before {
   content: "\f0d0";
 }
-/* line 195, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-truck:before {
   content: "\f0d1";
 }
-/* line 196, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-pinterest:before {
   content: "\f0d2";
 }
-/* line 197, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-pinterest-sign:before {
   content: "\f0d3";
 }
-/* line 198, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-google-plus-sign:before {
   content: "\f0d4";
 }
-/* line 199, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-google-plus:before {
   content: "\f0d5";
 }
-/* line 200, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-money:before {
   content: "\f0d6";
 }
-/* line 201, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-caret-down:before {
   content: "\f0d7";
 }
-/* line 202, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-caret-up:before {
   content: "\f0d8";
 }
-/* line 203, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-caret-left:before {
   content: "\f0d9";
 }
-/* line 204, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-caret-right:before {
   content: "\f0da";
 }
-/* line 205, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-columns:before {
   content: "\f0db";
 }
-/* line 206, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-sort:before {
   content: "\f0dc";
 }
-/* line 207, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-sort-down:before {
   content: "\f0dd";
 }
-/* line 208, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-sort-up:before {
   content: "\f0de";
 }
-/* line 209, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-envelope:before {
   content: "\f0e0";
 }
-/* line 210, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-linkedin:before {
   content: "\f0e1";
 }
-/* line 211, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-rotate-left:before,
 .icon-undo:before {
   content: "\f0e2";
 }
-/* line 213, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-legal:before {
   content: "\f0e3";
 }
-/* line 214, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-dashboard:before {
   content: "\f0e4";
 }
-/* line 215, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-comment-alt:before {
   content: "\f0e5";
 }
-/* line 216, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-comments-alt:before {
   content: "\f0e6";
 }
-/* line 217, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-bolt:before {
   content: "\f0e7";
 }
-/* line 218, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-sitemap:before {
   content: "\f0e8";
 }
-/* line 219, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-umbrella:before {
   content: "\f0e9";
 }
-/* line 220, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-paste:before {
   content: "\f0ea";
 }
-/* line 221, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-lightbulb:before {
   content: "\f0eb";
 }
-/* line 222, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-exchange:before {
   content: "\f0ec";
 }
-/* line 223, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-cloud-download:before {
   content: "\f0ed";
 }
-/* line 224, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-cloud-upload:before {
   content: "\f0ee";
 }
-/* line 225, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-user-md:before {
   content: "\f0f0";
 }
-/* line 226, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-stethoscope:before {
   content: "\f0f1";
 }
-/* line 227, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-suitcase:before {
   content: "\f0f2";
 }
-/* line 228, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-bell-alt:before {
   content: "\f0f3";
 }
-/* line 229, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-coffee:before {
   content: "\f0f4";
 }
-/* line 230, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-food:before {
   content: "\f0f5";
 }
-/* line 231, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-file-text-alt:before {
   content: "\f0f6";
 }
-/* line 232, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-building:before {
   content: "\f0f7";
 }
-/* line 233, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-hospital:before {
   content: "\f0f8";
 }
-/* line 234, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-ambulance:before {
   content: "\f0f9";
 }
-/* line 235, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-medkit:before {
   content: "\f0fa";
 }
-/* line 236, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-fighter-jet:before {
   content: "\f0fb";
 }
-/* line 237, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-beer:before {
   content: "\f0fc";
 }
-/* line 238, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-h-sign:before {
   content: "\f0fd";
 }
-/* line 239, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-plus-sign-alt:before {
   content: "\f0fe";
 }
-/* line 240, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-double-angle-left:before {
   content: "\f100";
 }
-/* line 241, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-double-angle-right:before {
   content: "\f101";
 }
-/* line 242, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-double-angle-up:before {
   content: "\f102";
 }
-/* line 243, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-double-angle-down:before {
   content: "\f103";
 }
-/* line 244, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-angle-left:before {
   content: "\f104";
 }
-/* line 245, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-angle-right:before {
   content: "\f105";
 }
-/* line 246, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-angle-up:before {
   content: "\f106";
 }
-/* line 247, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-angle-down:before {
   content: "\f107";
 }
-/* line 248, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-desktop:before {
   content: "\f108";
 }
-/* line 249, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-laptop:before {
   content: "\f109";
 }
-/* line 250, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-tablet:before {
   content: "\f10a";
 }
-/* line 251, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-mobile-phone:before {
   content: "\f10b";
 }
-/* line 252, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-circle-blank:before {
   content: "\f10c";
 }
-/* line 253, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-quote-left:before {
   content: "\f10d";
 }
-/* line 254, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-quote-right:before {
   content: "\f10e";
 }
-/* line 255, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-spinner:before {
   content: "\f110";
 }
-/* line 256, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-circle:before {
   content: "\f111";
 }
-/* line 257, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-mail-reply:before,
 .icon-reply:before {
   content: "\f112";
 }
-/* line 259, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-github-alt:before {
   content: "\f113";
 }
-/* line 260, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-folder-close-alt:before {
   content: "\f114";
 }
-/* line 261, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-folder-open-alt:before {
   content: "\f115";
 }
-/* line 262, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-expand-alt:before {
   content: "\f116";
 }
-/* line 263, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-collapse-alt:before {
   content: "\f117";
 }
-/* line 264, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-smile:before {
   content: "\f118";
 }
-/* line 265, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-frown:before {
   content: "\f119";
 }
-/* line 266, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-meh:before {
   content: "\f11a";
 }
-/* line 267, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-gamepad:before {
   content: "\f11b";
 }
-/* line 268, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-keyboard:before {
   content: "\f11c";
 }
-/* line 269, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-flag-alt:before {
   content: "\f11d";
 }
-/* line 270, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-flag-checkered:before {
   content: "\f11e";
 }
-/* line 271, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-terminal:before {
   content: "\f120";
 }
-/* line 272, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-code:before {
   content: "\f121";
 }
-/* line 273, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-reply-all:before {
   content: "\f122";
 }
-/* line 274, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-mail-reply-all:before {
   content: "\f122";
 }
-/* line 275, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-star-half-full:before,
 .icon-star-half-empty:before {
   content: "\f123";
 }
-/* line 277, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-location-arrow:before {
   content: "\f124";
 }
-/* line 278, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-crop:before {
   content: "\f125";
 }
-/* line 279, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-code-fork:before {
   content: "\f126";
 }
-/* line 280, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-unlink:before {
   content: "\f127";
 }
-/* line 281, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-question:before {
   content: "\f128";
 }
-/* line 282, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-info:before {
   content: "\f129";
 }
-/* line 283, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-exclamation:before {
   content: "\f12a";
 }
-/* line 284, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-superscript:before {
   content: "\f12b";
 }
-/* line 285, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-subscript:before {
   content: "\f12c";
 }
-/* line 286, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-eraser:before {
   content: "\f12d";
 }
-/* line 287, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-puzzle-piece:before {
   content: "\f12e";
 }
-/* line 288, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-microphone:before {
   content: "\f130";
 }
-/* line 289, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-microphone-off:before {
   content: "\f131";
 }
-/* line 290, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-shield:before {
   content: "\f132";
 }
-/* line 291, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-calendar-empty:before {
   content: "\f133";
 }
-/* line 292, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-fire-extinguisher:before {
   content: "\f134";
 }
-/* line 293, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-rocket:before {
   content: "\f135";
 }
-/* line 294, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-maxcdn:before {
   content: "\f136";
 }
-/* line 295, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-chevron-sign-left:before {
   content: "\f137";
 }
-/* line 296, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-chevron-sign-right:before {
   content: "\f138";
 }
-/* line 297, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-chevron-sign-up:before {
   content: "\f139";
 }
-/* line 298, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-chevron-sign-down:before {
   content: "\f13a";
 }
-/* line 299, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-html5:before {
   content: "\f13b";
 }
-/* line 300, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-css3:before {
   content: "\f13c";
 }
-/* line 301, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-anchor:before {
   content: "\f13d";
 }
-/* line 302, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-unlock-alt:before {
   content: "\f13e";
 }
-/* line 303, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-bullseye:before {
   content: "\f140";
 }
-/* line 304, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-ellipsis-horizontal:before {
   content: "\f141";
 }
-/* line 305, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-ellipsis-vertical:before {
   content: "\f142";
 }
-/* line 306, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-rss-sign:before {
   content: "\f143";
 }
-/* line 307, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-play-sign:before {
   content: "\f144";
 }
-/* line 308, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-ticket:before {
   content: "\f145";
 }
-/* line 309, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-minus-sign-alt:before {
   content: "\f146";
 }
-/* line 310, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-check-minus:before {
   content: "\f147";
 }
-/* line 311, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-level-up:before {
   content: "\f148";
 }
-/* line 312, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-level-down:before {
   content: "\f149";
 }
-/* line 313, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-check-sign:before {
   content: "\f14a";
 }
-/* line 314, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-edit-sign:before {
   content: "\f14b";
 }
-/* line 315, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-external-link-sign:before {
   content: "\f14c";
 }
-/* line 316, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-share-sign:before {
   content: "\f14d";
 }
-/* line 317, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-compass:before {
   content: "\f14e";
 }
-/* line 318, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-collapse:before {
   content: "\f150";
 }
-/* line 319, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-collapse-top:before {
   content: "\f151";
 }
-/* line 320, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-expand:before {
   content: "\f152";
 }
-/* line 321, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-euro:before,
 .icon-eur:before {
   content: "\f153";
 }
-/* line 323, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-gbp:before {
   content: "\f154";
 }
-/* line 324, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-dollar:before,
 .icon-usd:before {
   content: "\f155";
 }
-/* line 326, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-rupee:before,
 .icon-inr:before {
   content: "\f156";
 }
-/* line 328, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-yen:before,
 .icon-jpy:before {
   content: "\f157";
 }
-/* line 330, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-renminbi:before,
 .icon-cny:before {
   content: "\f158";
 }
-/* line 332, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-won:before,
 .icon-krw:before {
   content: "\f159";
 }
-/* line 334, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-bitcoin:before,
 .icon-btc:before {
   content: "\f15a";
 }
-/* line 336, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-file:before {
   content: "\f15b";
 }
-/* line 337, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-file-text:before {
   content: "\f15c";
 }
-/* line 338, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-sort-by-alphabet:before {
   content: "\f15d";
 }
-/* line 339, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-sort-by-alphabet-alt:before {
   content: "\f15e";
 }
-/* line 340, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-sort-by-attributes:before {
   content: "\f160";
 }
-/* line 341, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-sort-by-attributes-alt:before {
   content: "\f161";
 }
-/* line 342, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-sort-by-order:before {
   content: "\f162";
 }
-/* line 343, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-sort-by-order-alt:before {
   content: "\f163";
 }
-/* line 344, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-thumbs-up:before {
   content: "\f164";
 }
-/* line 345, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-thumbs-down:before {
   content: "\f165";
 }
-/* line 346, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-youtube-sign:before {
   content: "\f166";
 }
-/* line 347, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-youtube:before {
   content: "\f167";
 }
-/* line 348, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-xing:before {
   content: "\f168";
 }
-/* line 349, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-xing-sign:before {
   content: "\f169";
 }
-/* line 350, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-youtube-play:before {
   content: "\f16a";
 }
-/* line 351, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-dropbox:before {
   content: "\f16b";
 }
-/* line 352, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-stackexchange:before {
   content: "\f16c";
 }
-/* line 353, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-instagram:before {
   content: "\f16d";
 }
-/* line 354, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-flickr:before {
   content: "\f16e";
 }
-/* line 355, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-adn:before {
   content: "\f170";
 }
-/* line 356, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-bitbucket:before {
   content: "\f171";
 }
-/* line 357, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-bitbucket-sign:before {
   content: "\f172";
 }
-/* line 358, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-tumblr:before {
   content: "\f173";
 }
-/* line 359, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-tumblr-sign:before {
   content: "\f174";
 }
-/* line 360, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-long-arrow-down:before {
   content: "\f175";
 }
-/* line 361, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-long-arrow-up:before {
   content: "\f176";
 }
-/* line 362, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-long-arrow-left:before {
   content: "\f177";
 }
-/* line 363, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-long-arrow-right:before {
   content: "\f178";
 }
-/* line 364, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-apple:before {
   content: "\f179";
 }
-/* line 365, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-windows:before {
   content: "\f17a";
 }
-/* line 366, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-android:before {
   content: "\f17b";
 }
-/* line 367, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-linux:before {
   content: "\f17c";
 }
-/* line 368, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-dribbble:before {
   content: "\f17d";
 }
-/* line 369, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-skype:before {
   content: "\f17e";
 }
-/* line 370, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-foursquare:before {
   content: "\f180";
 }
-/* line 371, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-trello:before {
   content: "\f181";
 }
-/* line 372, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-female:before {
   content: "\f182";
 }
-/* line 373, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-male:before {
   content: "\f183";
 }
-/* line 374, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-gittip:before {
   content: "\f184";
 }
-/* line 375, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-sun:before {
   content: "\f185";
 }
-/* line 376, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-moon:before {
   content: "\f186";
 }
-/* line 377, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-archive:before {
   content: "\f187";
 }
-/* line 378, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-bug:before {
   content: "\f188";
 }
-/* line 379, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-vk:before {
   content: "\f189";
 }
-/* line 380, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-weibo:before {
   content: "\f18a";
 }
-/* line 381, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/icons.less */
 .icon-renren:before {
   content: "\f18b";
 }
-/* line 5, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-header.less */
 .site-header {
   padding-top: 40px;
   padding-bottom: 40px;
 }
-/* line 10, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-header.less */
 .site-header .title-area {
   position: relative;
   min-height: 1px;
@@ -9221,13 +7516,11 @@ a .icon-flip-vertical:before {
   padding-right: 15px;
 }
 @media (min-width: 1200px) {
-  /* line 627, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   .site-header .title-area {
     float: left;
     width: 50%;
   }
 }
-/* line 14, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-header.less */
 .site-header .header-widget-area {
   position: relative;
   min-height: 1px;
@@ -9235,23 +7528,19 @@ a .icon-flip-vertical:before {
   padding-right: 15px;
 }
 @media (min-width: 1200px) {
-  /* line 627, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   .site-header .header-widget-area {
     float: left;
     width: 50%;
   }
 }
-/* line 17, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-header.less */
 .site-header .header-widget-area > .widget {
   line-height: 46px;
   float: right;
 }
-/* line 23, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-header.less */
 .site-header .site-title {
   margin: 0 15px 0 0;
   float: left;
 }
-/* line 27, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-header.less */
 .site-header .site-title a {
   background: url('assets/images/logo.png') no-repeat;
   display: block;
@@ -9261,7 +7550,6 @@ a .icon-flip-vertical:before {
   height: 46px;
   width: 212px;
 }
-/* line 38, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-header.less */
 .site-header .site-description {
   float: left;
   border-left: 1px solid #e8e8e8;
@@ -9274,25 +7562,21 @@ a .icon-flip-vertical:before {
   font-size: 14px;
   font-size: 1.4rem;
 }
-/* line 52, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-header.less */
 #title a {
   width: 100%;
 }
-/* line 5, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-images.less */
 img {
   border-radius: 2px;
   display: block;
   max-width: 100%;
   height: auto;
 }
-/* line 11, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-images.less */
 img.alignleft {
   float: left !important;
   float: left;
   margin-right: 10px;
   margin-bottom: 10px;
 }
-/* line 17, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-images.less */
 img.aligncenter {
   text-align: center;
   margin-bottom: 10px;
@@ -9300,14 +7584,12 @@ img.aligncenter {
   max-width: 100%;
   height: auto;
 }
-/* line 23, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-images.less */
 img.alignright {
   float: right !important;
   float: right;
   margin-left: 10px;
   margin-bottom: 10px;
 }
-/* line 6, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-navbar.less */
 .nav-primary {
   position: relative;
   z-index: 1000;
@@ -9319,7 +7601,6 @@ img.alignright {
   background-color: #ffffff;
   border-color: #eeeeee;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .nav-primary:before,
 .nav-primary:after {
   content: " ";
@@ -9329,11 +7610,9 @@ img.alignright {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .nav-primary:after {
   clear: both;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .nav-primary:before,
 .nav-primary:after {
   content: " ";
@@ -9343,116 +7622,95 @@ img.alignright {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .nav-primary:after {
   clear: both;
 }
 @media (min-width: 768px) {
-  /* line 21, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .nav-primary {
     border-radius: 4px;
   }
 }
-/* line 357, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .nav-primary .navbar-brand {
   color: #777777;
 }
-/* line 359, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .nav-primary .navbar-brand:hover,
 .nav-primary .navbar-brand:focus {
   color: #5e5e5e;
   background-color: transparent;
 }
-/* line 366, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .nav-primary .navbar-text {
   color: #777777;
 }
-/* line 371, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .nav-primary .navbar-nav > li > a {
   color: #777777;
 }
-/* line 374, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .nav-primary .navbar-nav > li > a:hover,
 .nav-primary .navbar-nav > li > a:focus {
   color: #333333;
   background-color: transparent;
 }
-/* line 381, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .nav-primary .navbar-nav > .active > a,
 .nav-primary .navbar-nav > .active > a:hover,
 .nav-primary .navbar-nav > .active > a:focus {
   color: #555555;
   background-color: #eeeeee;
 }
-/* line 389, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .nav-primary .navbar-nav > .disabled > a,
 .nav-primary .navbar-nav > .disabled > a:hover,
 .nav-primary .navbar-nav > .disabled > a:focus {
   color: #cccccc;
   background-color: transparent;
 }
-/* line 398, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .nav-primary .navbar-toggle {
   border-color: #dddddd;
 }
-/* line 400, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .nav-primary .navbar-toggle:hover,
 .nav-primary .navbar-toggle:focus {
   background-color: #dddddd;
 }
-/* line 404, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .nav-primary .navbar-toggle .icon-bar {
   background-color: #cccccc;
 }
-/* line 409, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .nav-primary .navbar-collapse,
 .nav-primary .navbar-form {
   border-color: #ededed;
 }
-/* line 417, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .nav-primary .navbar-nav > .dropdown > a:hover .caret,
 .nav-primary .navbar-nav > .dropdown > a:focus .caret {
   border-top-color: #333333;
   border-bottom-color: #333333;
 }
-/* line 425, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .nav-primary .navbar-nav > .open > a,
 .nav-primary .navbar-nav > .open > a:hover,
 .nav-primary .navbar-nav > .open > a:focus {
   background-color: #eeeeee;
   color: #555555;
 }
-/* line 430, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .nav-primary .navbar-nav > .open > a .caret,
 .nav-primary .navbar-nav > .open > a:hover .caret,
 .nav-primary .navbar-nav > .open > a:focus .caret {
   border-top-color: #555555;
   border-bottom-color: #555555;
 }
-/* line 436, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .nav-primary .navbar-nav > .dropdown > a .caret {
   border-top-color: #777777;
   border-bottom-color: #777777;
 }
 @media (max-width: 767px) {
-  /* line 445, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .nav-primary .navbar-nav .open .dropdown-menu > li > a {
     color: #777777;
   }
-  /* line 447, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .nav-primary .navbar-nav .open .dropdown-menu > li > a:hover,
   .nav-primary .navbar-nav .open .dropdown-menu > li > a:focus {
     color: #333333;
     background-color: transparent;
   }
-  /* line 454, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .nav-primary .navbar-nav .open .dropdown-menu > .active > a,
   .nav-primary .navbar-nav .open .dropdown-menu > .active > a:hover,
   .nav-primary .navbar-nav .open .dropdown-menu > .active > a:focus {
     color: #555555;
     background-color: #eeeeee;
   }
-  /* line 462, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .nav-primary .navbar-nav .open .dropdown-menu > .disabled > a,
   .nav-primary .navbar-nav .open .dropdown-menu > .disabled > a:hover,
   .nav-primary .navbar-nav .open .dropdown-menu > .disabled > a:focus {
@@ -9460,19 +7718,15 @@ img.alignright {
     background-color: transparent;
   }
 }
-/* line 478, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .nav-primary .navbar-link {
   color: #777777;
 }
-/* line 480, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .nav-primary .navbar-link:hover {
   color: #333333;
 }
-/* line 10, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-navbar.less */
 .nav-primary .navbar-brand {
   display: none !important;
 }
-/* line 15, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-navbar.less */
 .nav-primary.affix {
   position: fixed;
   right: 0;
@@ -9485,85 +7739,69 @@ img.alignright {
   border-width: 1px 0;
 }
 @media (min-width: 768px) {
-  /* line 134, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .nav-primary.affix {
     border-radius: 0;
   }
 }
-/* line 493, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .nav-primary.affix .navbar-brand {
   color: #999999;
 }
-/* line 495, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .nav-primary.affix .navbar-brand:hover,
 .nav-primary.affix .navbar-brand:focus {
   color: #ffffff;
   background-color: transparent;
 }
-/* line 502, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .nav-primary.affix .navbar-text {
   color: #999999;
 }
-/* line 507, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .nav-primary.affix .navbar-nav > li > a {
   color: #999999;
 }
-/* line 510, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .nav-primary.affix .navbar-nav > li > a:hover,
 .nav-primary.affix .navbar-nav > li > a:focus {
   color: #ffffff;
   background-color: transparent;
 }
-/* line 517, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .nav-primary.affix .navbar-nav > .active > a,
 .nav-primary.affix .navbar-nav > .active > a:hover,
 .nav-primary.affix .navbar-nav > .active > a:focus {
   color: #ffffff;
   background-color: #080808;
 }
-/* line 525, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .nav-primary.affix .navbar-nav > .disabled > a,
 .nav-primary.affix .navbar-nav > .disabled > a:hover,
 .nav-primary.affix .navbar-nav > .disabled > a:focus {
   color: #444444;
   background-color: transparent;
 }
-/* line 535, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .nav-primary.affix .navbar-toggle {
   border-color: #333333;
 }
-/* line 537, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .nav-primary.affix .navbar-toggle:hover,
 .nav-primary.affix .navbar-toggle:focus {
   background-color: #333333;
 }
-/* line 541, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .nav-primary.affix .navbar-toggle .icon-bar {
   background-color: #ffffff;
 }
-/* line 546, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .nav-primary.affix .navbar-collapse,
 .nav-primary.affix .navbar-form {
   border-color: #101010;
 }
-/* line 554, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .nav-primary.affix .navbar-nav > .open > a,
 .nav-primary.affix .navbar-nav > .open > a:hover,
 .nav-primary.affix .navbar-nav > .open > a:focus {
   background-color: #080808;
   color: #ffffff;
 }
-/* line 561, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .nav-primary.affix .navbar-nav > .dropdown > a:hover .caret {
   border-top-color: #ffffff;
   border-bottom-color: #ffffff;
 }
-/* line 565, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .nav-primary.affix .navbar-nav > .dropdown > a .caret {
   border-top-color: #999999;
   border-bottom-color: #999999;
 }
-/* line 573, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .nav-primary.affix .navbar-nav > .open > a .caret,
 .nav-primary.affix .navbar-nav > .open > a:hover .caret,
 .nav-primary.affix .navbar-nav > .open > a:focus .caret {
@@ -9571,28 +7809,23 @@ img.alignright {
   border-bottom-color: #ffffff;
 }
 @media (max-width: 767px) {
-  /* line 583, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .nav-primary.affix .navbar-nav .open .dropdown-menu > .dropdown-header {
     border-color: #080808;
   }
-  /* line 586, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .nav-primary.affix .navbar-nav .open .dropdown-menu > li > a {
     color: #999999;
   }
-  /* line 588, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .nav-primary.affix .navbar-nav .open .dropdown-menu > li > a:hover,
   .nav-primary.affix .navbar-nav .open .dropdown-menu > li > a:focus {
     color: #ffffff;
     background-color: transparent;
   }
-  /* line 595, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .nav-primary.affix .navbar-nav .open .dropdown-menu > .active > a,
   .nav-primary.affix .navbar-nav .open .dropdown-menu > .active > a:hover,
   .nav-primary.affix .navbar-nav .open .dropdown-menu > .active > a:focus {
     color: #ffffff;
     background-color: #080808;
   }
-  /* line 603, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
   .nav-primary.affix .navbar-nav .open .dropdown-menu > .disabled > a,
   .nav-primary.affix .navbar-nav .open .dropdown-menu > .disabled > a:hover,
   .nav-primary.affix .navbar-nav .open .dropdown-menu > .disabled > a:focus {
@@ -9600,69 +7833,54 @@ img.alignright {
     background-color: transparent;
   }
 }
-/* line 614, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .nav-primary.affix .navbar-link {
   color: #999999;
 }
-/* line 616, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/navbar.less */
 .nav-primary.affix .navbar-link:hover {
   color: #ffffff;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-navbar.less */
 .nav-primary.affix .navbar-brand {
   display: block !important;
 }
-/* line 24, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-navbar.less */
 .admin-bar .nav-primary.affix {
   top: 32px;
 }
-/* line 28, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-navbar.less */
 .nav-primary.affix .menu-primary > li {
   border-color: #111;
 }
-/* line 32, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-navbar.less */
 .nav-primary.affix + * {
   margin-top: 48px;
 }
-/* line 38, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-navbar.less */
 .dropdown-menu {
   border-radius: 0;
   margin-top: 1px;
   margin-left: -1px;
   border-width: 0 1px 1px 1px;
 }
-/* line 45, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-navbar.less */
 .dropdown-submenu > .dropdown-menu {
   margin-top: -5px;
 }
-/* line 49, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-navbar.less */
 .navbar {
   border-radius: 0;
   margin-bottom: 0;
 }
-/* line 56, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-navbar.less */
 .menu-primary .dropdown-menu {
   min-width: 180px;
 }
-/* line 60, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-navbar.less */
 .menu-primary > li {
   border-right: 1px solid #e8e8e8;
 }
-/* line 63, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-navbar.less */
 .menu-primary > li:first-child {
   border-left: 1px solid #e8e8e8;
 }
-/* line 67, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-navbar.less */
 .menu-primary > li.open > a {
   background-color: #f8f8f8;
 }
-/* line 71, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-navbar.less */
 .menu-primary > li.current-menu-parent > a,
 .menu-primary > li.current-menu-item > a,
 .menu-primary > li.open > a {
   color: #333333;
 }
-/* line 82, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-navbar.less */
 nav > .menu > li[class^="icon-"] {
   line-height: 36px;
   position: relative;
@@ -9679,7 +7897,6 @@ nav > .menu > li[class^="icon-"] {
   text-align: center;
   vertical-align: middle;
 }
-/* line 95, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-navbar.less */
 nav > .menu > li[class^="icon-"] > a {
   position: absolute;
   left: 0;
@@ -9691,18 +7908,15 @@ nav > .menu > li[class^="icon-"] > a {
   width: 36px;
   height: 36px;
 }
-/* line 7, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-slider.less */
 .section-1 {
   background: #f9f9f9;
   border-bottom: 1px solid #e8e8e8;
   max-height: 340px;
 }
-/* line 15, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-slider.less */
 .section-1 .ft-responsive-slider .slider-inner {
   margin-left: -15px;
   margin-right: -15px;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .section-1 .ft-responsive-slider .slider-inner:before,
 .section-1 .ft-responsive-slider .slider-inner:after {
   content: " ";
@@ -9712,11 +7926,9 @@ nav > .menu > li[class^="icon-"] > a {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .section-1 .ft-responsive-slider .slider-inner:after {
   clear: both;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .section-1 .ft-responsive-slider .slider-inner:before,
 .section-1 .ft-responsive-slider .slider-inner:after {
   content: " ";
@@ -9726,11 +7938,9 @@ nav > .menu > li[class^="icon-"] > a {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .section-1 .ft-responsive-slider .slider-inner:after {
   clear: both;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .section-1 .ft-responsive-slider .slides:before,
 .section-1 .ft-responsive-slider .slides:after {
   content: " ";
@@ -9740,11 +7950,9 @@ nav > .menu > li[class^="icon-"] > a {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .section-1 .ft-responsive-slider .slides:after {
   clear: both;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .section-1 .ft-responsive-slider .slides:before,
 .section-1 .ft-responsive-slider .slides:after {
   content: " ";
@@ -9754,16 +7962,13 @@ nav > .menu > li[class^="icon-"] > a {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .section-1 .ft-responsive-slider .slides:after {
   clear: both;
 }
-/* line 22, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-slider.less */
 .section-1 .ft-responsive-slider .slides > li {
   position: relative;
   display: block;
 }
-/* line 27, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-slider.less */
 .section-1 .ft-responsive-slider .slides h2 {
   font-size: 36px;
   font-size: 3.6rem;
@@ -9771,22 +7976,18 @@ nav > .menu > li[class^="icon-"] > a {
   margin-top: 0;
   margin-bottom: 1.6rem;
 }
-/* line 34, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-slider.less */
 .section-1 .ft-responsive-slider .slides h2 > a {
   color: #5d5d5d;
 }
-/* line 37, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-slider.less */
 .section-1 .ft-responsive-slider .slides h2 > a:hover {
   text-decoration: none;
 }
-/* line 42, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-slider.less */
 .section-1 .ft-responsive-slider .slides p {
   font-size: 16px;
   font-size: 1.6rem;
   font-weight: 200;
   line-height: 2.6rem;
 }
-/* line 49, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-slider.less */
 .section-1 .ft-responsive-slider .slides .slide-image > img,
 .section-1 .ft-responsive-slider .slides .slide-image > a > img {
   display: block;
@@ -9794,19 +7995,16 @@ nav > .menu > li[class^="icon-"] > a {
   height: auto;
   line-height: 1;
 }
-/* line 60, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-slider.less */
 .section-1 .ft-responsive-slider .flex-control-nav > li,
 .section-1 .ft-responsive-slider .flex-direction-nav > li {
   display: inline-block;
   vertical-align: middle;
 }
-/* line 64, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-slider.less */
 .section-1 .ft-responsive-slider .flex-control-nav > li > a,
 .section-1 .ft-responsive-slider .flex-direction-nav > li > a {
   display: block;
   cursor: pointer;
 }
-/* line 71, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-slider.less */
 .section-1 .ft-responsive-slider .flex-control-nav {
   text-align: center;
   position: absolute;
@@ -9815,7 +8013,6 @@ nav > .menu > li[class^="icon-"] > a {
   margin-left: -30%;
   margin-top: 10px;
 }
-/* line 80, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-slider.less */
 .section-1 .ft-responsive-slider .flex-control-nav > li > a {
   font: 0/0 a;
   color: transparent;
@@ -9829,12 +8026,10 @@ nav > .menu > li[class^="icon-"] > a {
   background-color: #ffffff;
   border-radius: 10px;
 }
-/* line 88, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-slider.less */
 .section-1 .ft-responsive-slider .flex-control-nav > li > a.flex-active {
   border-color: #428bca;
   background-color: #428bca;
 }
-/* line 95, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-slider.less */
 .section-1 .ft-responsive-slider .flex-direction-nav {
   position: absolute;
   top: 50%;
@@ -9842,7 +8037,6 @@ nav > .menu > li[class^="icon-"] > a {
   opacity: 0;
   filter: alpha(opacity=0);
 }
-/* line 102, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-slider.less */
 .section-1 .ft-responsive-slider .flex-direction-nav > li {
   top: -13px;
   right: -5%;
@@ -9850,11 +8044,9 @@ nav > .menu > li[class^="icon-"] > a {
   height: 26px;
   position: absolute;
 }
-/* line 108, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-slider.less */
 .section-1 .ft-responsive-slider .flex-direction-nav > li:first-child {
   left: -5%;
 }
-/* line 112, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-slider.less */
 .section-1 .ft-responsive-slider .flex-direction-nav > li > a {
   width: 26px;
   height: 26px;
@@ -9867,35 +8059,29 @@ nav > .menu > li[class^="icon-"] > a {
   background: none;
   line-height: 1;
 }
-/* line 127, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-slider.less */
 .section-1 .ft-responsive-slider .flex-direction-nav > li > a.flex-prev:before {
   content: "\f053";
 }
-/* line 131, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-slider.less */
 .section-1 .ft-responsive-slider .flex-direction-nav > li > a.flex-next:before {
   content: "\f054";
 }
-/* line 142, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-slider.less */
 .section-container:hover .flex-direction-nav {
   -webkit-transition: opacity 0.15s linear;
   transition: opacity 0.15s linear;
   opacity: 1;
 }
-/* line 7, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-subheader.less */
 .site-subheader {
   padding-top: 40px;
   padding-bottom: 40px;
   background: #f9f9f9;
   border-bottom: 1px solid #e8e8e8;
 }
-/* line 15, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-subheader.less */
 .site-subheader .entry-title {
   font-size: 28px;
   font-size: 2.8rem;
   font-weight: 300;
   margin: 0;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-subheader.less */
 .site-subheader .subheader-area {
   position: relative;
   min-height: 1px;
@@ -9903,28 +8089,23 @@ nav > .menu > li[class^="icon-"] > a {
   padding-right: 15px;
 }
 @media (min-width: 1200px) {
-  /* line 627, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   .site-subheader .subheader-area {
     float: left;
     width: 50%;
   }
 }
-/* line 23, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-subheader.less */
 .site-subheader .subheader-area .breadcrumb {
   margin: 0;
   padding: 10px 0 0;
   color: #999999;
 }
-/* line 28, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-subheader.less */
 .site-subheader .subheader-area .breadcrumb > a {
   display: inline-block;
 }
-/* line 30, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-subheader.less */
 .site-subheader .subheader-area .breadcrumb > a:after {
   padding: 0 5px;
   color: #cccccc;
 }
-/* line 38, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-subheader.less */
 .site-subheader .subheader-widget-area {
   position: relative;
   min-height: 1px;
@@ -9932,43 +8113,35 @@ nav > .menu > li[class^="icon-"] > a {
   padding-right: 15px;
 }
 @media (min-width: 1200px) {
-  /* line 627, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   .site-subheader .subheader-widget-area {
     float: left;
     width: 50%;
   }
 }
-/* line 7, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-jumbotron.less */
 .ft-jumbotron {
   font-size: 16px;
   font-size: 1.6rem;
   font-weight: 200;
   background-color: none;
 }
-/* line 12, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-jumbotron.less */
 .ft-jumbotron .ft-jumbotron-detail {
   overflow: hidden;
   zoom: 1;
 }
-/* line 16, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-jumbotron.less */
 .ft-jumbotron .ft-jumbotron-detail span {
   font-size: 21px;
   font-size: 2.1rem;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-jumbotron.less */
 .ft-jumbotron .ft-jumbotron-detail p {
   margin: 0;
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-jumbotron.less */
 .ft-jumbotron .ft-jumbotron-action {
   margin-top: 10px;
 }
-/* line 30, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-jumbotron.less */
 .ft-jumbotron > .widget-wrap {
   overflow: hidden;
   zoom: 1;
 }
-/* line 8, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-inner.less */
 .widget h4 {
   margin-top: 0;
   font-size: 22px;
@@ -9976,36 +8149,30 @@ nav > .menu > li[class^="icon-"] > a {
   font-family: 'Source Sans Pro', sans-serif;
   font-weight: 300;
 }
-/* line 15, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-inner.less */
 .widget .widgettitle {
   max-height: 38px;
   margin-bottom: 2rem;
 }
-/* line 22, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-inner.less */
 .ft-featured-page i {
   margin-right: 5px;
   font-size: 21px;
   font-size: 2.1rem;
 }
-/* line 27, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-inner.less */
 .ft-featured-page .btn {
   padding: 0.5rem 1rem;
 }
-/* line 7, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-footer.less */
 .footer-widgets {
   background: #424242;
   color: #fff;
   padding: 40px 0px 40px 0px;
   padding: 4rem 0rem 4rem 0rem;
 }
-/* line 13, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-footer.less */
 .site-footer {
   background: #353535;
   color: #fff;
   padding: 20px 0px 20px 0px;
   padding: 2rem 0rem 2rem 0rem;
 }
-/* line 18, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-footer.less */
 .site-footer .copyright-area {
   position: relative;
   min-height: 1px;
@@ -10014,13 +8181,11 @@ nav > .menu > li[class^="icon-"] > a {
   text-align: center;
 }
 @media (min-width: 1200px) {
-  /* line 627, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   .site-footer .copyright-area {
     float: left;
     width: 100%;
   }
 }
-/* line 23, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-footer.less */
 .site-footer .footer-widget-area {
   position: relative;
   min-height: 1px;
@@ -10028,64 +8193,52 @@ nav > .menu > li[class^="icon-"] > a {
   padding-right: 15px;
 }
 @media (min-width: 1200px) {
-  /* line 627, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   .site-footer .footer-widget-area {
     float: left;
     width: 50%;
   }
 }
-/* line 26, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-footer.less */
 .site-footer .footer-widget-area > span {
   float: right;
 }
-/* line 9, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .widget ul,
 .widget ol {
   margin-bottom: 0;
   padding-left: 0;
 }
-/* line 15, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .widget hr {
   border-top: 1px dashed #e8e8e8;
   border-bottom: 1px dashed #fff;
   border-bottom: 1px dashed rgba(255, 255, 255, 0.5);
 }
-/* line 24, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .ft-tabbed-content .widgettitle {
   position: relative;
 }
-/* line 28, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .ft-tabbed-content .btn-group {
   margin-left: 15px;
   position: absolute;
   top: -4px;
 }
-/* line 33, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .ft-tabbed-content .btn-group .btn {
   padding: 0;
 }
-/* line 36, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .ft-tabbed-content .btn-group .btn a {
   text-transform: capitalize;
   display: inline-block;
   padding: 5px 10px;
   color: #333333;
 }
-/* line 42, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .ft-tabbed-content .btn-group .btn a:hover {
   text-decoration: none;
 }
-/* line 48, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .ft-tabbed-content .btn-group .btn.active {
   -webkit-box-shadow: none;
   box-shadow: none;
 }
-/* line 53, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .ft-tabbed-content .list-group-item {
   padding: 20px 0;
   border: none;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .ft-tabbed-content .list-group-item:before,
 .ft-tabbed-content .list-group-item:after {
   content: " ";
@@ -10095,11 +8248,9 @@ nav > .menu > li[class^="icon-"] > a {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .ft-tabbed-content .list-group-item:after {
   clear: both;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .ft-tabbed-content .list-group-item:before,
 .ft-tabbed-content .list-group-item:after {
   content: " ";
@@ -10109,70 +8260,56 @@ nav > .menu > li[class^="icon-"] > a {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .ft-tabbed-content .list-group-item:after {
   clear: both;
 }
-/* line 58, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .ft-tabbed-content .list-group-item:first-child {
   padding-top: 0;
 }
-/* line 62, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .ft-tabbed-content .list-group-item + .list-group-item {
   border-top: 1px dashed #e8e8e8;
 }
-/* line 66, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .ft-tabbed-content .list-group-item h4 {
   font-size: 20px;
   font-size: 2rem;
 }
-/* line 70, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .ft-tabbed-content .list-group-item > .pull-left img {
   margin-right: 10px;
 }
-/* line 74, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .ft-tabbed-content .list-group-item > .pull-right img {
   margin-left: 10px;
 }
-/* line 79, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .ft-tabbed-content .wp-tag-cloud > li {
   display: inline-block;
   margin-bottom: 10px;
   margin-right: 5px;
 }
-/* line 86, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .ft-tabbed-content .tab-pane-comments .avatar {
   border-radius: 30px;
 }
-/* line 97, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .ft-testimonials blockquote {
   background: #f9f9f9;
   border-left: 5px solid #e8e8e8;
 }
-/* line 100, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .ft-testimonials blockquote > p {
   font-size: 14px;
   font-size: 1.4rem;
   font-weight: normal;
   line-height: inherit;
 }
-/* line 114, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .sidebar .widget:first-child {
   padding-top: 0;
   border-top: none;
 }
-/* line 119, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .sidebar .widget {
   border-top: 1px solid #e8e8e8;
   padding-bottom: 30px;
   padding-top: 30px;
 }
-/* line 126, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .sidebar .widget_calendar caption {
   text-transform: uppercase;
   padding: 0 0 10px;
 }
-/* line 131, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .sidebar .widget_calendar table {
   width: 100%;
   margin-bottom: 20px;
@@ -10181,7 +8318,6 @@ nav > .menu > li[class^="icon-"] > a {
   position: relative;
   margin-bottom: 0;
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tables.less */
 .sidebar .widget_calendar table thead > tr > th,
 .sidebar .widget_calendar table tbody > tr > th,
 .sidebar .widget_calendar table tfoot > tr > th,
@@ -10193,12 +8329,10 @@ nav > .menu > li[class^="icon-"] > a {
   vertical-align: top;
   border-top: 1px solid #e8e8e8;
 }
-/* line 35, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tables.less */
 .sidebar .widget_calendar table thead > tr > th {
   vertical-align: bottom;
   border-bottom: 2px solid #e8e8e8;
 }
-/* line 44, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tables.less */
 .sidebar .widget_calendar table caption + thead tr:first-child th,
 .sidebar .widget_calendar table colgroup + thead tr:first-child th,
 .sidebar .widget_calendar table thead:first-child tr:first-child th,
@@ -10207,16 +8341,13 @@ nav > .menu > li[class^="icon-"] > a {
 .sidebar .widget_calendar table thead:first-child tr:first-child td {
   border-top: 0;
 }
-/* line 50, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tables.less */
 .sidebar .widget_calendar table tbody + tbody {
   border-top: 2px solid #e8e8e8;
 }
-/* line 55, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/tables.less */
 .sidebar .widget_calendar table .table,
 .sidebar .widget_calendar table table {
   background-color: #ffffff;
 }
-/* line 138, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .sidebar .widget_calendar table thead > tr > th {
   text-align: center;
   font-weight: 600;
@@ -10225,7 +8356,6 @@ nav > .menu > li[class^="icon-"] > a {
   border: none;
   background-color: #fafafa;
 }
-/* line 146, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .sidebar .widget_calendar table tbody > tr > td {
   padding: 7px;
   border: none;
@@ -10235,30 +8365,24 @@ nav > .menu > li[class^="icon-"] > a {
   background: #fafafa;
   border-radius: 0.2em;
 }
-/* line 154, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .sidebar .widget_calendar table tbody > tr > td.pad {
   background: none;
 }
-/* line 159, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .sidebar .widget_calendar table tfoot {
   position: absolute;
   top: 0;
   border-spacing: 0;
 }
-/* line 161, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .sidebar .widget_calendar table tfoot > tr > td {
   padding-top: 0;
   border-top: none;
 }
-/* line 169, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .sidebar .widget_calendar table tfoot a {
   white-space: nowrap;
 }
-/* line 173, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .sidebar .widget_calendar table tfoot .pad {
   width: 100%;
 }
-/* line 191, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .sidebar .widget_pages > .widget-wrap ul.children,
 .sidebar .widget_categories > .widget-wrap ul.children,
 .sidebar .widget_archive > .widget-wrap ul.children,
@@ -10268,7 +8392,6 @@ nav > .menu > li[class^="icon-"] > a {
 .sidebar .widget_nav_menu > .widget-wrap ul.children {
   margin-top: 10px;
 }
-/* line 196, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .sidebar .widget_pages li,
 .sidebar .widget_categories li,
 .sidebar .widget_archive li,
@@ -10283,7 +8406,6 @@ nav > .menu > li[class^="icon-"] > a {
   display: block;
   padding: 10px 0 0 20px;
 }
-/* line 202, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .sidebar .widget_pages li:before,
 .sidebar .widget_categories li:before,
 .sidebar .widget_archive li:before,
@@ -10297,7 +8419,6 @@ nav > .menu > li[class^="icon-"] > a {
   font-family: FontAwesome;
   content: "\f105";
 }
-/* line 210, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .sidebar .widget_pages li:first-child,
 .sidebar .widget_categories li:first-child,
 .sidebar .widget_archive li:first-child,
@@ -10307,7 +8428,6 @@ nav > .menu > li[class^="icon-"] > a {
 .sidebar .widget_nav_menu li:first-child {
   padding-top: 0;
 }
-/* line 214, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .sidebar .widget_pages li .icon,
 .sidebar .widget_categories li .icon,
 .sidebar .widget_archive li .icon,
@@ -10319,7 +8439,6 @@ nav > .menu > li[class^="icon-"] > a {
   float: left;
   text-align: left;
 }
-/* line 220, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .sidebar .widget_pages li .badge,
 .sidebar .widget_categories li .badge,
 .sidebar .widget_archive li .badge,
@@ -10330,7 +8449,6 @@ nav > .menu > li[class^="icon-"] > a {
   float: right;
   border-radius: 0.25em;
 }
-/* line 233, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .sidebar .widget_rss > .widget-wrap > ul a.rsswidget {
   font-family: 'Open Sans', sans-serif;
   font-weight: 500;
@@ -10338,18 +8456,15 @@ nav > .menu > li[class^="icon-"] > a {
   font-size: 24px;
   font-weight: 300;
 }
-/* line 55, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/type.less */
 .sidebar .widget_rss > .widget-wrap > ul a.rsswidget small {
   font-weight: normal;
   line-height: 1;
   color: #999999;
 }
-/* line 237, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .sidebar .widget_rss > .widget-wrap > ul a.rsswidget:after {
   content: " ";
   display: block;
 }
-/* line 244, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .sidebar .widget_rss > .widget-wrap li {
   position: relative;
   display: block;
@@ -10357,12 +8472,10 @@ nav > .menu > li[class^="icon-"] > a {
   margin: 15px 0 0;
   border-top: 1px dashed #e8e8e8;
 }
-/* line 251, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .sidebar .widget_rss > .widget-wrap li:first-child {
   padding-top: 0;
   border-top: none;
 }
-/* line 257, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .sidebar .widget_rss > .widget-wrap .rss-date {
   display: inline;
   padding: .2em .6em .3em;
@@ -10383,22 +8496,18 @@ nav > .menu > li[class^="icon-"] > a {
   display: inline-block;
   margin: 5px 0 0;
 }
-/* line 19, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/labels.less */
 .sidebar .widget_rss > .widget-wrap .rss-date[href]:hover,
 .sidebar .widget_rss > .widget-wrap .rss-date[href]:focus {
   color: #ffffff;
   text-decoration: none;
   cursor: pointer;
 }
-/* line 28, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/labels.less */
 .sidebar .widget_rss > .widget-wrap .rss-date:empty {
   display: none;
 }
-/* line 13, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-blog-pages.less */
 .sidebar .widget_rss > .widget-wrap .rss-date a {
   color: #b6b6b6;
 }
-/* line 263, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .sidebar .widget_rss > .widget-wrap .rss-date:before {
   font-family: FontAwesome;
   content: "\f017";
@@ -10406,11 +8515,9 @@ nav > .menu > li[class^="icon-"] > a {
   font-size: 1.3rem;
   padding: 0 5px 0 0;
 }
-/* line 272, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .sidebar .widget_rss > .widget-wrap .rssSummary {
   margin: 5px 0 0;
 }
-/* line 276, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .sidebar .widget_rss > .widget-wrap cite {
   font-size: 12px;
   font-size: 1.2rem;
@@ -10418,14 +8525,12 @@ nav > .menu > li[class^="icon-"] > a {
   margin: 5px 0 0;
   color: #b6b6b6;
 }
-/* line 282, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .sidebar .widget_rss > .widget-wrap cite:before {
   font-family: FontAwesome;
   content: "\2014 \00A0";
   font-size: 13px;
   font-size: 1.3rem;
 }
-/* line 297, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .sidebar .widget_tag_cloud .tagcloud > ul > li {
   display: inline;
   padding: .2em .6em .3em;
@@ -10443,32 +8548,26 @@ nav > .menu > li[class^="icon-"] > a {
   font-size: 100%;
   font-weight: normal;
 }
-/* line 19, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/labels.less */
 .sidebar .widget_tag_cloud .tagcloud > ul > li[href]:hover,
 .sidebar .widget_tag_cloud .tagcloud > ul > li[href]:focus {
   color: #ffffff;
   text-decoration: none;
   cursor: pointer;
 }
-/* line 28, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/labels.less */
 .sidebar .widget_tag_cloud .tagcloud > ul > li:empty {
   display: none;
 }
-/* line 478, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .sidebar .widget_tag_cloud .tagcloud > ul > li[href]:hover,
 .sidebar .widget_tag_cloud .tagcloud > ul > li[href]:focus {
   background-color: #808080;
 }
-/* line 305, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-widgets.less */
 .sidebar .widget_tag_cloud .tagcloud > ul > li > a {
   color: #fff;
 }
-/* line 12, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-layouts.less */
 .content-sidebar-wrap {
   min-height: 100%;
   overflow: hidden;
 }
-/* line 18, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-layouts.less */
 .full-width-content .content {
   position: relative;
   min-height: 1px;
@@ -10478,13 +8577,11 @@ nav > .menu > li[class^="icon-"] > a {
   padding-bottom: 40px;
 }
 @media (min-width: 1200px) {
-  /* line 627, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   .full-width-content .content {
     float: left;
     width: 100%;
   }
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .full-width-content .content:before,
 .full-width-content .content:after {
   content: " ";
@@ -10494,11 +8591,9 @@ nav > .menu > li[class^="icon-"] > a {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .full-width-content .content:after {
   clear: both;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .full-width-content .content:before,
 .full-width-content .content:after {
   content: " ";
@@ -10508,11 +8603,9 @@ nav > .menu > li[class^="icon-"] > a {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .full-width-content .content:after {
   clear: both;
 }
-/* line 28, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-layouts.less */
 .content-sidebar .content,
 .sidebar-content .content {
   position: relative;
@@ -10524,14 +8617,12 @@ nav > .menu > li[class^="icon-"] > a {
   padding-bottom: 9999px;
 }
 @media (min-width: 1200px) {
-  /* line 627, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   .content-sidebar .content,
   .sidebar-content .content {
     float: left;
     width: 75%;
   }
 }
-/* line 33, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-layouts.less */
 .content-sidebar .sidebar-primary,
 .sidebar-content .sidebar-primary {
   position: relative;
@@ -10543,14 +8634,12 @@ nav > .menu > li[class^="icon-"] > a {
   padding-bottom: 9999px;
 }
 @media (min-width: 1200px) {
-  /* line 627, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   .content-sidebar .sidebar-primary,
   .sidebar-content .sidebar-primary {
     float: left;
     width: 25%;
   }
 }
-/* line 42, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-layouts.less */
 .content-sidebar-sidebar .content,
 .sidebar-sidebar-content .content,
 .sidebar-content-sidebar .content {
@@ -10563,7 +8652,6 @@ nav > .menu > li[class^="icon-"] > a {
   padding-bottom: 9999px;
 }
 @media (min-width: 1200px) {
-  /* line 627, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   .content-sidebar-sidebar .content,
   .sidebar-sidebar-content .content,
   .sidebar-content-sidebar .content {
@@ -10571,7 +8659,6 @@ nav > .menu > li[class^="icon-"] > a {
     width: 58.333333333333336%;
   }
 }
-/* line 47, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-layouts.less */
 .content-sidebar-sidebar .sidebar-primary,
 .sidebar-sidebar-content .sidebar-primary,
 .sidebar-content-sidebar .sidebar-primary {
@@ -10584,7 +8671,6 @@ nav > .menu > li[class^="icon-"] > a {
   padding-bottom: 9999px;
 }
 @media (min-width: 1200px) {
-  /* line 627, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   .content-sidebar-sidebar .sidebar-primary,
   .sidebar-sidebar-content .sidebar-primary,
   .sidebar-content-sidebar .sidebar-primary {
@@ -10592,7 +8678,6 @@ nav > .menu > li[class^="icon-"] > a {
     width: 25%;
   }
 }
-/* line 52, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-layouts.less */
 .content-sidebar-sidebar .sidebar-secondary,
 .sidebar-sidebar-content .sidebar-secondary,
 .sidebar-content-sidebar .sidebar-secondary {
@@ -10605,7 +8690,6 @@ nav > .menu > li[class^="icon-"] > a {
   padding-bottom: 9999px;
 }
 @media (min-width: 1200px) {
-  /* line 627, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   .content-sidebar-sidebar .sidebar-secondary,
   .sidebar-sidebar-content .sidebar-secondary,
   .sidebar-content-sidebar .sidebar-secondary {
@@ -10613,126 +8697,104 @@ nav > .menu > li[class^="icon-"] > a {
     width: 16.666666666666664%;
   }
 }
-/* line 59, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-layouts.less */
 .content-sidebar .content {
   padding-right: 30px;
 }
-/* line 63, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-layouts.less */
 .content-sidebar .sidebar-primary {
   padding-left: 30px;
   border-left: 1px solid #e8e8e8;
 }
-/* line 70, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-layouts.less */
 .sidebar-content .content {
   padding-right: 15px;
   padding-left: 30px;
 }
 @media (min-width: 1200px) {
-  /* line 640, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   .sidebar-content .content {
     left: 25%;
   }
 }
-/* line 76, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-layouts.less */
 .sidebar-content .sidebar-primary {
   padding-right: 30px;
   padding-left: 15px;
   border-right: 1px solid #e8e8e8;
 }
 @media (min-width: 1200px) {
-  /* line 645, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   .sidebar-content .sidebar-primary {
     right: 75%;
   }
 }
-/* line 85, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-layouts.less */
 .content-sidebar-sidebar .content {
   padding-right: 30px;
   padding-left: 15px;
 }
-/* line 90, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-layouts.less */
 .content-sidebar-sidebar .sidebar-primary {
   padding-right: 30px;
   padding-left: 30px;
   border-left: 1px solid #e8e8e8;
 }
-/* line 96, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-layouts.less */
 .content-sidebar-sidebar .sidebar-secondary {
   padding-right: 15px;
   padding-left: 30px;
   border-left: 1px solid #e8e8e8;
 }
-/* line 104, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-layouts.less */
 .sidebar-sidebar-content .content {
   padding-right: 15px;
   padding-left: 30px;
 }
 @media (min-width: 1200px) {
-  /* line 640, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   .sidebar-sidebar-content .content {
     left: 41.66666666666667%;
   }
 }
-/* line 110, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-layouts.less */
 .sidebar-sidebar-content .sidebar-primary {
   padding-right: 30px;
   padding-left: 30px;
   border-right: 1px solid #e8e8e8;
 }
 @media (min-width: 1200px) {
-  /* line 645, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   .sidebar-sidebar-content .sidebar-primary {
     right: 41.66666666666667%;
   }
 }
-/* line 117, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-layouts.less */
 .sidebar-sidebar-content .sidebar-secondary {
   padding-right: 30px;
   padding-left: 15px;
   border-right: 1px solid #e8e8e8;
 }
 @media (min-width: 1200px) {
-  /* line 645, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   .sidebar-sidebar-content .sidebar-secondary {
     right: 83.33333333333334%;
   }
 }
-/* line 126, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-layouts.less */
 .sidebar-content-sidebar .content {
   padding-right: 30px;
   padding-left: 30px;
 }
 @media (min-width: 1200px) {
-  /* line 640, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   .sidebar-content-sidebar .content {
     left: 16.666666666666664%;
   }
 }
-/* line 132, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-layouts.less */
 .sidebar-content-sidebar .sidebar-primary {
   padding-right: 15px;
   padding-left: 30px;
   border-left: 1px solid #e8e8e8;
 }
 @media (min-width: 1200px) {
-  /* line 640, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   .sidebar-content-sidebar .sidebar-primary {
     left: 16.666666666666664%;
   }
 }
-/* line 139, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-layouts.less */
 .sidebar-content-sidebar .sidebar-secondary {
   padding-right: 30px;
   padding-left: 15px;
   border-right: 1px solid #e8e8e8;
 }
 @media (min-width: 1200px) {
-  /* line 645, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
   .sidebar-content-sidebar .sidebar-secondary {
     right: 83.33333333333334%;
   }
 }
-/* line 3, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-blog-pages.less */
 .entry-time,
 .entry-author,
 .entry-comments-link,
@@ -10752,7 +8814,6 @@ nav > .menu > li[class^="icon-"] > a {
   background-color: #f9f9f9;
   color: #b6b6b6;
 }
-/* line 19, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/labels.less */
 .entry-time[href]:hover,
 .entry-author[href]:hover,
 .entry-comments-link[href]:hover,
@@ -10765,27 +8826,23 @@ nav > .menu > li[class^="icon-"] > a {
   text-decoration: none;
   cursor: pointer;
 }
-/* line 28, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/labels.less */
 .entry-time:empty,
 .entry-author:empty,
 .entry-comments-link:empty,
 .entry-categories:empty {
   display: none;
 }
-/* line 13, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-blog-pages.less */
 .entry-time a,
 .entry-author a,
 .entry-comments-link a,
 .entry-categories a {
   color: #b6b6b6;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-blog-pages.less */
 .content article {
   margin: 40px 0;
   padding: 40px 0 0;
   border-top: 1px dashed #e8e8e8;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .content article:before,
 .content article:after {
   content: " ";
@@ -10795,11 +8852,9 @@ nav > .menu > li[class^="icon-"] > a {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .content article:after {
   clear: both;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .content article:before,
 .content article:after {
   content: " ";
@@ -10809,28 +8864,23 @@ nav > .menu > li[class^="icon-"] > a {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .content article:after {
   clear: both;
 }
-/* line 27, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-blog-pages.less */
 .content article:first-child {
   margin-top: 0;
   padding-top: 0;
   border-top: none;
 }
-/* line 33, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-blog-pages.less */
 .content article .entry-title {
   margin: 0 0 5px;
   line-height: 1;
 }
-/* line 39, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-blog-pages.less */
 .content .pagination {
   margin: 0 0 40px;
   list-style: none;
   text-align: center;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .content .pagination:before,
 .content .pagination:after {
   content: " ";
@@ -10840,11 +8890,9 @@ nav > .menu > li[class^="icon-"] > a {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .content .pagination:after {
   clear: both;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .content .pagination:before,
 .content .pagination:after {
   content: " ";
@@ -10854,15 +8902,12 @@ nav > .menu > li[class^="icon-"] > a {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .content .pagination:after {
   clear: both;
 }
-/* line 46, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-blog-pages.less */
 .content .pagination > div {
   display: inline;
 }
-/* line 48, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-blog-pages.less */
 .content .pagination > div > a,
 .content .pagination > div > span {
   color: #333333;
@@ -10872,23 +8917,19 @@ nav > .menu > li[class^="icon-"] > a {
   border: 1px solid #cccccc;
   border-radius: 15px;
 }
-/* line 58, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-blog-pages.less */
 .content .pagination > div > a:hover,
 .content .pagination > div > a:focus {
   text-decoration: none;
   background-color: #eeeeee;
 }
-/* line 66, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-blog-pages.less */
 .content .pagination .alignright > a,
 .content .pagination .alignright > span {
   float: right;
 }
-/* line 73, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-blog-pages.less */
 .content .pagination .alignleft > a,
 .content .pagination .alignleft > span {
   float: left;
 }
-/* line 80, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-blog-pages.less */
 .content .pagination .disabled > a,
 .content .pagination .disabled > a:hover,
 .content .pagination .disabled > a:focus,
@@ -10897,17 +8938,14 @@ nav > .menu > li[class^="icon-"] > a {
   background-color: #ffffff;
   cursor: default;
 }
-/* line 90, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-blog-pages.less */
 .content .pagination > ul {
   margin-bottom: 0;
   padding-left: 0;
   border-radius: 4px;
 }
-/* line 95, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-blog-pages.less */
 .content .pagination > ul > li {
   display: inline;
 }
-/* line 99, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-blog-pages.less */
 .content .pagination > ul > li > a,
 .content .pagination > ul > li > span {
   color: #333333;
@@ -10919,20 +8957,17 @@ nav > .menu > li[class^="icon-"] > a {
   border: 1px solid #cccccc;
   border-left-width: 0;
 }
-/* line 111, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-blog-pages.less */
 .content .pagination > ul > li > a:hover,
 .content .pagination > ul > li > a:focus,
 .content .pagination > ul > .active > a,
 .content .pagination > ul > .active > span {
   background-color: #eeeeee;
 }
-/* line 118, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-blog-pages.less */
 .content .pagination > ul > .active > a,
 .content .pagination > ul > .active > span {
   color: #999999;
   cursor: default;
 }
-/* line 124, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-blog-pages.less */
 .content .pagination > ul > .disabled > span,
 .content .pagination > ul > .disabled > a,
 .content .pagination > ul > .disabled > a:hover,
@@ -10941,30 +8976,25 @@ nav > .menu > li[class^="icon-"] > a {
   background-color: #ffffff;
   cursor: default;
 }
-/* line 133, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-blog-pages.less */
 .content .pagination > ul > li:first-child > a,
 .content .pagination > ul > li:first-child > span {
   border-left-width: 1px;
   border-bottom-left-radius: 4px;
   border-top-left-radius: 4px;
 }
-/* line 139, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-blog-pages.less */
 .content .pagination > ul > li:last-child > a,
 .content .pagination > ul > li:last-child > span {
   border-bottom-right-radius: 4px;
   border-top-right-radius: 4px;
 }
-/* line 3, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-comments.less */
 .entry-comments {
   position: relative;
   margin-bottom: 40px;
 }
-/* line 8, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-comments.less */
 .entry-comments + .comment-respond {
   margin-bottom: 40px;
   margin-top: -40px;
 }
-/* line 14, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-comments.less */
 .entry-comments > h3 {
   font-size: 22px;
   font-size: 2.2rem;
@@ -10992,69 +9022,56 @@ nav > .menu > li[class^="icon-"] > a {
 	color: #fff;
 	top: -1px;
 }*/
-/* line 42, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-comments.less */
 .comment-list {
   padding-left: 0;
   margin: 0;
 }
-/* line 46, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-comments.less */
 .comment-list .comment {
   display: block;
 }
-/* line 50, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-comments.less */
 .comment-list > .comment {
   margin-left: 24px;
   padding: 40px 0 0 30px;
   border-left: 1px dashed #e8e8e8;
 }
-/* line 56, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-comments.less */
 .comment-list > .comment:first-child {
   padding-top: 0;
 }
-/* line 61, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-comments.less */
 .comment-list > .comment > article {
   border-bottom: 1px dashed #e8e8e8;
   margin: 0;
   padding: 0 0 40px 0;
 }
-/* line 67, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-comments.less */
 .comment-list > .comment > .children {
   border-top: none;
   border-bottom: 1px dashed #e8e8e8;
   padding-bottom: 30px;
   padding-top: 0;
 }
-/* line 76, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-comments.less */
 .comment-list article + .children {
   border-top: 1px dashed #e8e8e8;
   padding-top: 20px;
   margin-top: 20px;
 }
-/* line 82, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-comments.less */
 .comment-list .children {
   padding-left: 0;
   position: relative;
 }
-/* line 86, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-comments.less */
 .comment-list .children .comment ~ .comment {
   border-top: 1px dashed #e8e8e8;
   margin: 20px 0 0 0;
   padding: 20px 0 0 54px;
 }
-/* line 92, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-comments.less */
 .comment-list .children article {
   margin: 0;
 }
-/* line 96, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-comments.less */
 .comment-list .children .comment {
   margin-left: 24px;
   padding-left: 30px;
 }
-/* line 102, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-comments.less */
 .comment-list .comment-header {
   height: 48px;
 }
-/* line 111, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-comments.less */
 .comment-list .comment-reply-link {
   display: inline-block;
   padding: 6px 12px;
@@ -11083,19 +9100,16 @@ nav > .menu > li[class^="icon-"] > a {
   padding: 1px 5px;
   text-transform: uppercase;
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/buttons.less */
 .comment-list .comment-reply-link:focus {
   outline: thin dotted #333;
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }
-/* line 29, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/buttons.less */
 .comment-list .comment-reply-link:hover,
 .comment-list .comment-reply-link:focus {
   color: #333333;
   text-decoration: none;
 }
-/* line 35, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/buttons.less */
 .comment-list .comment-reply-link:active,
 .comment-list .comment-reply-link.active {
   outline: 0;
@@ -11103,7 +9117,6 @@ nav > .menu > li[class^="icon-"] > a {
   -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
 }
-/* line 42, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/buttons.less */
 .comment-list .comment-reply-link.disabled,
 .comment-list .comment-reply-link[disabled],
 fieldset[disabled] .comment-list .comment-reply-link {
@@ -11114,29 +9127,24 @@ fieldset[disabled] .comment-list .comment-reply-link {
   -webkit-box-shadow: none;
   box-shadow: none;
 }
-/* line 41, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/bootstrap.less */
 .comment-list .comment-reply-link [class^="icon-"].icon-large,
 .comment-list .comment-reply-link [class*=" icon-"].icon-large {
   line-height: .9em;
 }
-/* line 42, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/bootstrap.less */
 .comment-list .comment-reply-link [class^="icon-"].icon-spin,
 .comment-list .comment-reply-link [class*=" icon-"].icon-spin {
   display: inline-block;
 }
-/* line 55, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/bootstrap.less */
 .comment-list .comment-reply-link [class^="icon-"].pull-left.icon-2x,
 .comment-list .comment-reply-link [class*=" icon-"].pull-left.icon-2x,
 .comment-list .comment-reply-link [class^="icon-"].pull-right.icon-2x,
 .comment-list .comment-reply-link [class*=" icon-"].pull-right.icon-2x {
   margin-top: .18em;
 }
-/* line 57, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/bootstrap.less */
 .comment-list .comment-reply-link [class^="icon-"].icon-spin.icon-large,
 .comment-list .comment-reply-link [class*=" icon-"].icon-spin.icon-large {
   line-height: .8em;
 }
-/* line 412, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .comment-list .comment-reply-link:hover,
 .comment-list .comment-reply-link:focus,
 .comment-list .comment-reply-link:active,
@@ -11146,13 +9154,11 @@ fieldset[disabled] .comment-list .comment-reply-link {
   background-color: #ebebeb;
   border-color: #adadad;
 }
-/* line 421, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .comment-list .comment-reply-link:active,
 .comment-list .comment-reply-link.active,
 .open .dropdown-toggle.comment-list .comment-reply-link {
   background-image: none;
 }
-/* line 429, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .comment-list .comment-reply-link.disabled,
 .comment-list .comment-reply-link[disabled],
 fieldset[disabled] .comment-list .comment-reply-link,
@@ -11171,7 +9177,6 @@ fieldset[disabled] .comment-list .comment-reply-link.active {
   background-color: #ffffff;
   border-color: #cccccc;
 }
-/* line 412, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .comment-list .comment-reply-link:hover,
 .comment-list .comment-reply-link:focus,
 .comment-list .comment-reply-link:active,
@@ -11181,13 +9186,11 @@ fieldset[disabled] .comment-list .comment-reply-link.active {
   background-color: #ebebeb;
   border-color: #adadad;
 }
-/* line 421, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .comment-list .comment-reply-link:active,
 .comment-list .comment-reply-link.active,
 .open .dropdown-toggle.comment-list .comment-reply-link {
   background-image: none;
 }
-/* line 429, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .comment-list .comment-reply-link.disabled,
 .comment-list .comment-reply-link[disabled],
 fieldset[disabled] .comment-list .comment-reply-link,
@@ -11206,35 +9209,29 @@ fieldset[disabled] .comment-list .comment-reply-link.active {
   background-color: #ffffff;
   border-color: #cccccc;
 }
-/* line 118, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-comments.less */
 .comment-list .comment-author {
   font-size: 16px;
   font-size: 1.6rem;
   margin-bottom: 0;
 }
-/* line 122, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-comments.less */
 .comment-list .comment-author > img {
   position: absolute;
   left: 0;
   border-radius: 50%;
 }
-/* line 129, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-comments.less */
 .comment-list .comment-meta {
   font-size: 12px;
   font-size: 1.2rem;
 }
-/* line 135, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-comments.less */
 .comment-respond {
   position: relative;
   background: #f9f9f9;
   padding: 30px;
   margin-left: 24px;
 }
-/* line 141, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-comments.less */
 .comment-respond .comment-reply-title {
   margin: 0 0 20px;
 }
-/* line 144, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-comments.less */
 .comment-respond .comment-reply-title > small > a {
   display: inline-block;
   padding: 6px 12px;
@@ -11264,19 +9261,16 @@ fieldset[disabled] .comment-list .comment-reply-link.active {
   margin: 0 0 5px 5px;
   text-transform: uppercase;
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/buttons.less */
 .comment-respond .comment-reply-title > small > a:focus {
   outline: thin dotted #333;
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }
-/* line 29, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/buttons.less */
 .comment-respond .comment-reply-title > small > a:hover,
 .comment-respond .comment-reply-title > small > a:focus {
   color: #333333;
   text-decoration: none;
 }
-/* line 35, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/buttons.less */
 .comment-respond .comment-reply-title > small > a:active,
 .comment-respond .comment-reply-title > small > a.active {
   outline: 0;
@@ -11284,7 +9278,6 @@ fieldset[disabled] .comment-list .comment-reply-link.active {
   -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
 }
-/* line 42, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/buttons.less */
 .comment-respond .comment-reply-title > small > a.disabled,
 .comment-respond .comment-reply-title > small > a[disabled],
 fieldset[disabled] .comment-respond .comment-reply-title > small > a {
@@ -11295,29 +9288,24 @@ fieldset[disabled] .comment-respond .comment-reply-title > small > a {
   -webkit-box-shadow: none;
   box-shadow: none;
 }
-/* line 41, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/bootstrap.less */
 .comment-respond .comment-reply-title > small > a [class^="icon-"].icon-large,
 .comment-respond .comment-reply-title > small > a [class*=" icon-"].icon-large {
   line-height: .9em;
 }
-/* line 42, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/bootstrap.less */
 .comment-respond .comment-reply-title > small > a [class^="icon-"].icon-spin,
 .comment-respond .comment-reply-title > small > a [class*=" icon-"].icon-spin {
   display: inline-block;
 }
-/* line 55, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/bootstrap.less */
 .comment-respond .comment-reply-title > small > a [class^="icon-"].pull-left.icon-2x,
 .comment-respond .comment-reply-title > small > a [class*=" icon-"].pull-left.icon-2x,
 .comment-respond .comment-reply-title > small > a [class^="icon-"].pull-right.icon-2x,
 .comment-respond .comment-reply-title > small > a [class*=" icon-"].pull-right.icon-2x {
   margin-top: .18em;
 }
-/* line 57, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/bootstrap.less */
 .comment-respond .comment-reply-title > small > a [class^="icon-"].icon-spin.icon-large,
 .comment-respond .comment-reply-title > small > a [class*=" icon-"].icon-spin.icon-large {
   line-height: .8em;
 }
-/* line 412, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .comment-respond .comment-reply-title > small > a:hover,
 .comment-respond .comment-reply-title > small > a:focus,
 .comment-respond .comment-reply-title > small > a:active,
@@ -11327,13 +9315,11 @@ fieldset[disabled] .comment-respond .comment-reply-title > small > a {
   background-color: #ebebeb;
   border-color: #adadad;
 }
-/* line 421, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .comment-respond .comment-reply-title > small > a:active,
 .comment-respond .comment-reply-title > small > a.active,
 .open .dropdown-toggle.comment-respond .comment-reply-title > small > a {
   background-image: none;
 }
-/* line 429, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .comment-respond .comment-reply-title > small > a.disabled,
 .comment-respond .comment-reply-title > small > a[disabled],
 fieldset[disabled] .comment-respond .comment-reply-title > small > a,
@@ -11352,7 +9338,6 @@ fieldset[disabled] .comment-respond .comment-reply-title > small > a.active {
   background-color: #ffffff;
   border-color: #cccccc;
 }
-/* line 412, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .comment-respond .comment-reply-title > small > a:hover,
 .comment-respond .comment-reply-title > small > a:focus,
 .comment-respond .comment-reply-title > small > a:active,
@@ -11362,13 +9347,11 @@ fieldset[disabled] .comment-respond .comment-reply-title > small > a.active {
   background-color: #ebebeb;
   border-color: #adadad;
 }
-/* line 421, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .comment-respond .comment-reply-title > small > a:active,
 .comment-respond .comment-reply-title > small > a.active,
 .open .dropdown-toggle.comment-respond .comment-reply-title > small > a {
   background-image: none;
 }
-/* line 429, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .comment-respond .comment-reply-title > small > a.disabled,
 .comment-respond .comment-reply-title > small > a[disabled],
 fieldset[disabled] .comment-respond .comment-reply-title > small > a,
@@ -11387,7 +9370,6 @@ fieldset[disabled] .comment-respond .comment-reply-title > small > a.active {
   background-color: #ffffff;
   border-color: #cccccc;
 }
-/* line 153, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-comments.less */
 .comment-respond .comment-notes {
   padding: 15px;
   margin-bottom: 20px;
@@ -11397,40 +9379,32 @@ fieldset[disabled] .comment-respond .comment-reply-title > small > a.active {
   border-color: #bce8f1;
   color: #3a87ad;
 }
-/* line 16, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/alerts.less */
 .comment-respond .comment-notes h4 {
   margin-top: 0;
   color: inherit;
 }
-/* line 22, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/alerts.less */
 .comment-respond .comment-notes .alert-link {
   font-weight: bold;
 }
-/* line 27, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/alerts.less */
 .comment-respond .comment-notes > p,
 .comment-respond .comment-notes > ul {
   margin-bottom: 0;
 }
-/* line 31, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/alerts.less */
 .comment-respond .comment-notes > p + p {
   margin-top: 5px;
 }
-/* line 366, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .comment-respond .comment-notes hr {
   border-top-color: #a6e1ec;
 }
-/* line 369, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .comment-respond .comment-notes .alert-link {
   color: #2d6987;
 }
-/* line 158, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-comments.less */
 .comment-respond .comment-form-author,
 .comment-respond .comment-form-email,
 .comment-respond .comment-form-url,
 .comment-respond .comment-form-comment {
   margin-bottom: 15px;
 }
-/* line 165, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-comments.less */
 .comment-respond select,
 .comment-respond input[type="text"],
 .comment-respond input[type="password"],
@@ -11463,7 +9437,6 @@ fieldset[disabled] .comment-respond .comment-reply-title > small > a.active {
   transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
   width: 50%;
 }
-/* line 57, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .comment-respond select:-moz-placeholder,
 .comment-respond input[type="text"]:-moz-placeholder,
 .comment-respond input[type="password"]:-moz-placeholder,
@@ -11481,7 +9454,6 @@ fieldset[disabled] .comment-respond .comment-reply-title > small > a.active {
 .comment-respond input[type="color"]:-moz-placeholder {
   color: #999999;
 }
-/* line 58, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .comment-respond select::-moz-placeholder,
 .comment-respond input[type="text"]::-moz-placeholder,
 .comment-respond input[type="password"]::-moz-placeholder,
@@ -11499,7 +9471,6 @@ fieldset[disabled] .comment-respond .comment-reply-title > small > a.active {
 .comment-respond input[type="color"]::-moz-placeholder {
   color: #999999;
 }
-/* line 59, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .comment-respond select:-ms-input-placeholder,
 .comment-respond input[type="text"]:-ms-input-placeholder,
 .comment-respond input[type="password"]:-ms-input-placeholder,
@@ -11517,7 +9488,6 @@ fieldset[disabled] .comment-respond .comment-reply-title > small > a.active {
 .comment-respond input[type="color"]:-ms-input-placeholder {
   color: #999999;
 }
-/* line 60, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .comment-respond select::-webkit-input-placeholder,
 .comment-respond input[type="text"]::-webkit-input-placeholder,
 .comment-respond input[type="password"]::-webkit-input-placeholder,
@@ -11535,7 +9505,6 @@ fieldset[disabled] .comment-respond .comment-reply-title > small > a.active {
 .comment-respond input[type="color"]::-webkit-input-placeholder {
   color: #999999;
 }
-/* line 695, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .comment-respond select:focus,
 .comment-respond input[type="text"]:focus,
 .comment-respond input[type="password"]:focus,
@@ -11556,7 +9525,6 @@ fieldset[disabled] .comment-respond .comment-reply-title > small > a.active {
   -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102, 175, 233, 0.6);
   box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102, 175, 233, 0.6);
 }
-/* line 139, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
 .comment-respond select[disabled],
 .comment-respond input[type="text"][disabled],
 .comment-respond input[type="password"][disabled],
@@ -11605,7 +9573,6 @@ fieldset[disabled] .comment-respond input[type="color"] {
   cursor: not-allowed;
   background-color: #eeeeee;
 }
-/* line 147, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
 textarea.comment-respond select,
 textarea.comment-respond input[type="text"],
 textarea.comment-respond input[type="password"],
@@ -11623,7 +9590,6 @@ textarea.comment-respond input[type="tel"],
 textarea.comment-respond input[type="color"] {
   height: auto;
 }
-/* line 184, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-comments.less */
 .comment-respond textarea {
   display: block;
   width: 100%;
@@ -11642,53 +9608,43 @@ textarea.comment-respond input[type="color"] {
   transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
   height: auto;
 }
-/* line 57, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .comment-respond textarea:-moz-placeholder {
   color: #999999;
 }
-/* line 58, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .comment-respond textarea::-moz-placeholder {
   color: #999999;
 }
-/* line 59, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .comment-respond textarea:-ms-input-placeholder {
   color: #999999;
 }
-/* line 60, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .comment-respond textarea::-webkit-input-placeholder {
   color: #999999;
 }
-/* line 695, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .comment-respond textarea:focus {
   border-color: #66afe9;
   outline: 0;
   -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102, 175, 233, 0.6);
   box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102, 175, 233, 0.6);
 }
-/* line 139, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
 .comment-respond textarea[disabled],
 .comment-respond textarea[readonly],
 fieldset[disabled] .comment-respond textarea {
   cursor: not-allowed;
   background-color: #eeeeee;
 }
-/* line 147, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/forms.less */
 textarea.comment-respond textarea {
   height: auto;
 }
-/* line 189, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-comments.less */
 .comment-respond .form-allowed-tags {
   display: block;
   margin-top: 5px;
   margin-bottom: 10px;
   color: #737373;
 }
-/* line 192, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-comments.less */
 .comment-respond .form-allowed-tags code {
   display: block;
   white-space: normal;
 }
-/* line 198, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-comments.less */
 .comment-respond input[type="submit"] {
   display: inline-block;
   padding: 6px 12px;
@@ -11711,19 +9667,16 @@ textarea.comment-respond textarea {
   background-color: #ffffff;
   border-color: #cccccc;
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/buttons.less */
 .comment-respond input[type="submit"]:focus {
   outline: thin dotted #333;
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }
-/* line 29, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/buttons.less */
 .comment-respond input[type="submit"]:hover,
 .comment-respond input[type="submit"]:focus {
   color: #333333;
   text-decoration: none;
 }
-/* line 35, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/buttons.less */
 .comment-respond input[type="submit"]:active,
 .comment-respond input[type="submit"].active {
   outline: 0;
@@ -11731,7 +9684,6 @@ textarea.comment-respond textarea {
   -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
 }
-/* line 42, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/buttons.less */
 .comment-respond input[type="submit"].disabled,
 .comment-respond input[type="submit"][disabled],
 fieldset[disabled] .comment-respond input[type="submit"] {
@@ -11742,29 +9694,24 @@ fieldset[disabled] .comment-respond input[type="submit"] {
   -webkit-box-shadow: none;
   box-shadow: none;
 }
-/* line 41, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/bootstrap.less */
 .comment-respond input[type="submit"] [class^="icon-"].icon-large,
 .comment-respond input[type="submit"] [class*=" icon-"].icon-large {
   line-height: .9em;
 }
-/* line 42, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/bootstrap.less */
 .comment-respond input[type="submit"] [class^="icon-"].icon-spin,
 .comment-respond input[type="submit"] [class*=" icon-"].icon-spin {
   display: inline-block;
 }
-/* line 55, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/bootstrap.less */
 .comment-respond input[type="submit"] [class^="icon-"].pull-left.icon-2x,
 .comment-respond input[type="submit"] [class*=" icon-"].pull-left.icon-2x,
 .comment-respond input[type="submit"] [class^="icon-"].pull-right.icon-2x,
 .comment-respond input[type="submit"] [class*=" icon-"].pull-right.icon-2x {
   margin-top: .18em;
 }
-/* line 57, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/font-awesome/less/bootstrap.less */
 .comment-respond input[type="submit"] [class^="icon-"].icon-spin.icon-large,
 .comment-respond input[type="submit"] [class*=" icon-"].icon-spin.icon-large {
   line-height: .8em;
 }
-/* line 412, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .comment-respond input[type="submit"]:hover,
 .comment-respond input[type="submit"]:focus,
 .comment-respond input[type="submit"]:active,
@@ -11774,13 +9721,11 @@ fieldset[disabled] .comment-respond input[type="submit"] {
   background-color: #ebebeb;
   border-color: #adadad;
 }
-/* line 421, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .comment-respond input[type="submit"]:active,
 .comment-respond input[type="submit"].active,
 .open .dropdown-toggle.comment-respond input[type="submit"] {
   background-image: none;
 }
-/* line 429, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .comment-respond input[type="submit"].disabled,
 .comment-respond input[type="submit"][disabled],
 fieldset[disabled] .comment-respond input[type="submit"],
@@ -11799,7 +9744,6 @@ fieldset[disabled] .comment-respond input[type="submit"].active {
   background-color: #ffffff;
   border-color: #cccccc;
 }
-/* line 412, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .comment-respond input[type="submit"]:hover,
 .comment-respond input[type="submit"]:focus,
 .comment-respond input[type="submit"]:active,
@@ -11809,13 +9753,11 @@ fieldset[disabled] .comment-respond input[type="submit"].active {
   background-color: #ebebeb;
   border-color: #adadad;
 }
-/* line 421, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .comment-respond input[type="submit"]:active,
 .comment-respond input[type="submit"].active,
 .open .dropdown-toggle.comment-respond input[type="submit"] {
   background-image: none;
 }
-/* line 429, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .comment-respond input[type="submit"].disabled,
 .comment-respond input[type="submit"][disabled],
 fieldset[disabled] .comment-respond input[type="submit"],
@@ -11907,18 +9849,15 @@ label {
 	margin-top: 32px;
 	margin-top: 2rem;
 }*/
-/* line 6, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-other.less */
 .site-container {
   border-top: 4px solid #2a2a2a;
   box-shadow: inset 0 1px 0 #e8e8e8;
 }
-/* line 15, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-other.less */
 .btn {
   color: #333333;
   background-color: #ffffff;
   border-color: #cccccc;
 }
-/* line 412, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .btn:hover,
 .btn:focus,
 .btn:active,
@@ -11928,13 +9867,11 @@ label {
   background-color: #ebebeb;
   border-color: #adadad;
 }
-/* line 421, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .btn:active,
 .btn.active,
 .open .dropdown-toggle.btn {
   background-image: none;
 }
-/* line 429, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .btn.disabled,
 .btn[disabled],
 fieldset[disabled] .btn,
@@ -11953,11 +9890,9 @@ fieldset[disabled] .btn.active {
   background-color: #ffffff;
   border-color: #cccccc;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-other.less */
 .section-container {
   padding: 40px 0;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .section-container:before,
 .section-container:after {
   content: " ";
@@ -11967,11 +9902,9 @@ fieldset[disabled] .btn.active {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .section-container:after {
   clear: both;
 }
-/* line 20, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .section-container:before,
 .section-container:after {
   content: " ";
@@ -11981,20 +9914,16 @@ fieldset[disabled] .btn.active {
   /* 2 */
 
 }
-/* line 25, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/vendor/bootstrap/less/mixins.less */
 .section-container:after {
   clear: both;
 }
-/* line 23, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-other.less */
 .section-container + .section-container {
   border-top: 1px solid #e8e8e8;
 }
-/* line 28, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-other.less */
 .ft-page-business .content {
   padding-top: 0;
   padding-bottom: 0;
 }
-/* line 37, /Users/ryanholder/Sites/Projects/forsitethemes/content/themes/fortytwo/assets/css/less/ft-other.less */
 .content > article > .entry-content > :first-child {
   margin-top: 0;
   padding-top: 0;


### PR DESCRIPTION
@mrdavidlaing I turns out the only unwanted options were the location_vertical and location_horizontal.

I wanted to remove the slider width and height and let the css control that but it turns out not to work as easily as expected.
